### PR TITLE
P/v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ application uses the same instance of the SDK.
 
 # <a name="errors"></a>Errors
 
-Errors returned from the SDK are of type `error`. When and error is returned from the API
+Errors returned from the SDK are of type `error`. When an error is returned from the API
 they will be of type `structs.ErrorStruct` (See [here](https://docs.abiosgaming.com/v2/reference#errors),
 otherwise they will just be forwarded as-is from the standard library.
 

--- a/README.md
+++ b/README.md
@@ -101,14 +101,14 @@ application uses the same instance of the SDK.
 # <a name="errors"></a>Errors
 
 Errors returned from the SDK are of type `error`. When an error is returned from the API
-they will be of type `structs.ErrorStruct` (See [here](https://docs.abiosgaming.com/v2/reference#errors),
+they will be of type `structs.Error` (See [here](https://docs.abiosgaming.com/v2/reference#errors),
 otherwise they will just be forwarded as-is from the standard library.
 
-The ErrorStruct implements the `Stringer` interface as well as the `error` interface.
+`structs.Error` implements the `Stringer` interface as well as the `error` interface.
 
 In order to implement the `error` interface a struct cannot have the field `Error` (as
 it would clash with the interface method). Therefore, what is returned with the json key
-`"error"` is available in `ErrorStruct` in the field `ErrorMessage`.
+`"error"` is available in `structs.Error` in the field `ErrorMessage`.
 
 # Endpoints
 For each endpoint in the /v2/ API you can expect to find a corresponding method implemented
@@ -188,7 +188,7 @@ team, _ := a.MatchesById(301281, nil)
 switch pbp := team.TeamStats.PlayByPlay.(type) {
 	case structs.DotaTeamStats:
 		// Do something
-	case structs.tsLolTeamStats:
+	case structs.LolTeamStats:
 		// Do something
 	case structs.CsTeamStats:
 		// Do something

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ otherwise they will just be forwarded as-is from the standard library.
 
 The ErrorStruct implements the `Stringer` interface as well as the `error` interface.
 
+In order to implement the `error` interface a struct cannot have the field `Error` (as
+it would clash with the interface method). Therefore, what is returned with the json key
+`"error"` is available in `ErrorStruct` in the field `ErrorMessage`.
+
 # Endpoints
 For each endpoint in the /v2/ API you can expect to find a corresponding method implemented
 on the struct returned by `abios.New`. The names of these method directly corresponds to

--- a/README.md
+++ b/README.md
@@ -26,14 +26,17 @@ create a pull request) and we'll get to it as soon as possible!
 # Installation
 
 ```Bash
-$ go get -u github.com/AbiosGaming/go-sdk-v2/
+$ go get -u github.com/AbiosGaming/go-sdk-v2
 ```
 
 ## Quick Start
+
 Add the import line:
 
 ```Go
 import "github.com/AbiosGaming/go-sdk-v2"
+
+import "github.com/AbiosGaming/go-sdk-v2/v3" // If you are using modules
 ```
 
 Use the function `abios.New(username, password string)` to create a new instance of the
@@ -181,6 +184,7 @@ with a team:
 ```go
 // Note that for this you have to import the structs sub-package
 import . "github.com/AbiosGaming/go-sdk-v2/structs"
+import . "github.com/AbiosGaming/go-sdk-v2/v3/structs" // If you are using modules
 
 team, _ := a.MatchesById(301281, nil)
 switch pbp := team.TeamStats.PlayByPlay.(type) {
@@ -212,7 +216,7 @@ package main
 
 import (
     "fmt"
-    "github.com/AbiosGaming/go-sdk-v2"
+    "github.com/AbiosGaming/go-sdk-v2/v3"
 )
 
 func main() {
@@ -242,7 +246,7 @@ package main
 
 import (
     "fmt"
-    "github.com/AbiosGaming/go-sdk-v2"
+    "github.com/AbiosGaming/go-sdk-v2/v3"
 )
 
 func main() {
@@ -291,7 +295,7 @@ package main
 
 import (
     "fmt"
-    "github.com/AbiosGaming/go-sdk-v2"
+    "github.com/AbiosGaming/go-sdk-v2/v3"
     "time"
 )
 
@@ -348,7 +352,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/AbiosGaming/go-sdk-v2"
+	"github.com/AbiosGaming/go-sdk-v2/v3"
 )
 
 // currentCalendar holds what we respond to our users

--- a/README.md
+++ b/README.md
@@ -101,16 +101,12 @@ outgoing rate. However, not every clock is synchronized with our server and not 
 application uses the same instance of the SDK.
 
 # <a name="errors"></a>Errors
-Errors returned from the SDK is **_not_** of type `error` but instead a pointer to a struct
-corresponding to the JSON returned from the endpoint when an error occurs. See [official documentation](https://docs.abiosgaming.com/v2/reference#errors).
 
-If no errors are returned type will be `<nil>`.
+Errors returned from the SDK are of type `error`. When and error is returned from the API
+they will be of type `structs.ErrorStruct` (See [here](https://docs.abiosgaming.com/v2/reference#errors),
+otherwise they will just be forwarded as-is from the standard library.
 
-The ErrorStruct implements the `Stringer` interface.
-
-Errors of type `error` will be forwarded to your application in the form of an ErrorStruct.
-The `ErrorCode` will then be equal to 0 and the `Error` will specify that is is an application
-error (rather than a client or server error).
+The ErrorStruct implements the `Stringer` interface as well as the `error` interface.
 
 # Endpoints
 For each endpoint in the /v2/ API you can expect to find a corresponding method implemented

--- a/README.md
+++ b/README.md
@@ -23,20 +23,12 @@ themselves see the [official documentation](https://docs.abiosgaming.com/).
 Find a bug? Missing a feature? Create an issue (or if you are feeling particularly ambitious,
 create a pull request) and we'll get to it as soon as possible!
 
-# Installation
-
-```Bash
-$ go get -u github.com/AbiosGaming/go-sdk-v2
-```
-
-## Quick Start
+# Quick Start
 
 Add the import line:
 
 ```Go
-import "github.com/AbiosGaming/go-sdk-v2"
-
-import "github.com/AbiosGaming/go-sdk-v2/v3" // If you are using modules
+import "github.com/AbiosGaming/go-sdk-v2/v3"
 ```
 
 Use the function `abios.New(username, password string)` to create a new instance of the
@@ -187,16 +179,15 @@ with a team:
 
 ```go
 // Note that for this you have to import the structs sub-package
-import . "github.com/AbiosGaming/go-sdk-v2/structs"
-import . "github.com/AbiosGaming/go-sdk-v2/v3/structs" // If you are using modules
+import "github.com/AbiosGaming/go-sdk-v2/v3/structs"
 
 team, _ := a.MatchesById(301281, nil)
 switch pbp := team.TeamStats.PlayByPlay.(type) {
-	case DotaTeamStats:
+	case structs.DotaTeamStats:
 		// Do something
-	case LolTeamStats:
+	case structs.tsLolTeamStats:
 		// Do something
-	case CsTeamStats:
+	case structs.CsTeamStats:
 		// Do something
 }
 ```

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Add the import line:
 import "github.com/AbiosGaming/go-sdk-v2/v3"
 ```
 
+and the go module system should find the package for you on your next build.
+
 Use the function `abios.New(username, password string)` to create a new instance of the
 abios struct and authenticate with the given credentials.
 
@@ -47,7 +49,8 @@ a.SetRate(5, 300)
 This will allow you to send 5 requests every second and up to 300 requests every minute.
 See [Outgoing Rate](#rate) for more information.
 
-To get all available games (from the /games endpoint) the following code will do:
+To get the first page of available games (from the /games endpoint) the following code
+will do:
 
 ```Go
 games, err := a.Games(nil)
@@ -155,7 +158,7 @@ will not be exceeded. See [Concurrent Use](#concurrent_example) for an example.
 
 The SDK will try to perform as many requests as possible concurrently. It will create one
 go-routine per request per second. For example, if the specified rate limit is 10 per
-second then every second up to 10 go-routines will be created, one for each request. 
+second then every second up to 10 go-routines will be created, one for each request.
 
 # Play by Play Data
 

--- a/abios_sdk.go
+++ b/abios_sdk.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	. "github.com/AbiosGaming/go-sdk-v2/structs"
+	. "github.com/AbiosGaming/go-sdk-v2/v3/structs"
 )
 
 // Constant variables that represents endpoints

--- a/abios_sdk.go
+++ b/abios_sdk.go
@@ -319,7 +319,7 @@ func (a *client) TeamsById(id int64, params Parameters) (TeamStruct, error) {
 	}
 
 	target := TeamStruct{}
-	err := json.Unmarshal(result.body, target)
+	err := json.Unmarshal(result.body, &target)
 	return target, err
 }
 
@@ -338,7 +338,7 @@ func (a *client) Organisations(params Parameters) (OrganisationStructPaginated, 
 	}
 
 	target := OrganisationStructPaginated{}
-	err := json.Unmarshal(result.body, target)
+	err := json.Unmarshal(result.body, &target)
 	return target, err
 }
 
@@ -354,7 +354,7 @@ func (a *client) OrganisationsById(id int64) (OrganisationStruct, error) {
 	}
 
 	target := OrganisationStruct{}
-	err := json.Unmarshal(result.body, target)
+	err := json.Unmarshal(result.body, &target)
 	return target, err
 }
 
@@ -373,7 +373,7 @@ func (a *client) Players(params Parameters) (PlayerStructPaginated, error) {
 	}
 
 	target := PlayerStructPaginated{}
-	err := json.Unmarshal(result.body, target)
+	err := json.Unmarshal(result.body, &target)
 	return target, err
 }
 
@@ -393,7 +393,7 @@ func (a *client) PlayersById(id int64, params Parameters) (PlayerStruct, error) 
 	}
 
 	target := PlayerStruct{}
-	err := json.Unmarshal(result.body, target)
+	err := json.Unmarshal(result.body, &target)
 	return target, err
 }
 
@@ -413,7 +413,7 @@ func (a *client) RostersById(id int64, params Parameters) (RosterStruct, error) 
 	}
 
 	target := RosterStruct{}
-	err := json.Unmarshal(result.body, target)
+	err := json.Unmarshal(result.body, &target)
 	return target, err
 }
 
@@ -434,7 +434,7 @@ func (a *client) Search(query string, params Parameters) ([]SearchResultStruct, 
 	}
 
 	target := []SearchResultStruct{}
-	err := json.Unmarshal(result.body, target)
+	err := json.Unmarshal(result.body, &target)
 	return target, err
 }
 
@@ -453,7 +453,7 @@ func (a *client) Incidents(params Parameters) (IncidentStructPaginated, error) {
 	}
 
 	target := IncidentStructPaginated{}
-	err := json.Unmarshal(result.body, target)
+	err := json.Unmarshal(result.body, &target)
 	return target, err
 }
 
@@ -469,7 +469,7 @@ func (a *client) IncidentsBySeriesId(id int64) (SeriesIncidentsStruct, error) {
 	}
 
 	target := SeriesIncidentsStruct{}
-	err := json.Unmarshal(result.body, target)
+	err := json.Unmarshal(result.body, &target)
 	return target, err
 }
 

--- a/abios_sdk.go
+++ b/abios_sdk.go
@@ -129,20 +129,20 @@ func (a *client) authenticate() *result {
 
 	statusCode, b, err := apiCall(req)
 	if err != nil {
-		return &result{statuscode: 0, body: nil, err: err}
+		return &result{body: nil, err: err}
 	}
 	dec := json.NewDecoder(bytes.NewBuffer(b))
 	if 200 <= statusCode && statusCode < 300 {
 		target := AccessTokenStruct{}
 		err := dec.Decode(&target)
 		if err != nil {
-			return &result{statuscode: 0, body: nil, err: err}
+			return &result{body: nil, err: err}
 		}
 		a.oauth = target
 		return nil
 	}
 
-	return &result{statuscode: statusCode, body: b, err: nil}
+	return &result{body: b, err: nil}
 }
 
 // Games queries the /games endpoint and returns a GameStructPaginated.

--- a/abios_sdk.go
+++ b/abios_sdk.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	. "github.com/AbiosGaming/go-sdk-v2/v3/structs"
+	"github.com/AbiosGaming/go-sdk-v2/v3/structs"
 )
 
 // Constant variables that represents endpoints
@@ -36,23 +36,23 @@ const (
 // AbiosSdk defines the interface of an implementation of a SDK targeting the Abios endpoints.
 type AbiosSdk interface {
 	SetRate(second, minute uint)
-	Games(params Parameters) (GameStructPaginated, error)
-	Series(params Parameters) (SeriesStructPaginated, error)
-	SeriesById(id int64, params Parameters) (SeriesStruct, error)
-	MatchesById(id int64, params Parameters) (MatchStruct, error)
-	Tournaments(params Parameters) (TournamentStructPaginated, error)
-	TournamentsById(id int64, params Parameters) (TournamentStruct, error)
-	SubstagesById(id int64, params Parameters) (SubstageStruct, error)
-	Teams(params Parameters) (TeamStructPaginated, error)
-	TeamsById(id int64, params Parameters) (TeamStruct, error)
-	Organisations(params Parameters) (OrganisationStructPaginated, error)
-	OrganisationsById(id int64) (OrganisationStruct, error)
-	Players(params Parameters) (PlayerStructPaginated, error)
-	PlayersById(id int64, params Parameters) (PlayerStruct, error)
-	RostersById(id int64, params Parameters) (RosterStruct, error)
-	Search(query string, params Parameters) ([]SearchResultStruct, error)
-	Incidents(params Parameters) (IncidentStructPaginated, error)
-	IncidentsBySeriesId(id int64) (SeriesIncidentsStruct, error)
+	Games(params Parameters) (structs.PaginatedGames, error)
+	Series(params Parameters) (structs.PaginatedSeries, error)
+	SeriesById(id int64, params Parameters) (structs.Series, error)
+	MatchesById(id int64, params Parameters) (structs.Match, error)
+	Tournaments(params Parameters) (structs.PaginatedTournaments, error)
+	TournamentsById(id int64, params Parameters) (structs.Tournament, error)
+	SubstagesById(id int64, params Parameters) (structs.Substage, error)
+	Teams(params Parameters) (structs.PaginatedTeams, error)
+	TeamsById(id int64, params Parameters) (structs.Team, error)
+	Organisations(params Parameters) (structs.PaginatedOrganisations, error)
+	OrganisationsById(id int64) (structs.Organisation, error)
+	Players(params Parameters) (structs.PaginatedPlayers, error)
+	PlayersById(id int64, params Parameters) (structs.Player, error)
+	RostersById(id int64, params Parameters) (structs.Roster, error)
+	Search(query string, params Parameters) ([]structs.SearchResult, error)
+	Incidents(params Parameters) (structs.PaginatedIncidents, error)
+	IncidentsBySeriesId(id int64) (structs.SeriesIncidents, error)
 }
 
 // client holds the oauth string returned from Authenticate as well as this sessions
@@ -60,7 +60,7 @@ type AbiosSdk interface {
 type client struct {
 	username string
 	password string
-	oauth    AccessTokenStruct
+	oauth    structs.AccessToken
 	handler  *requestHandler
 	base_url string
 }
@@ -103,7 +103,7 @@ func New(username, password string) *client {
 // NewAbios returns a new endpoint-wrapper for api version 2 with given credentials and baseUrl.
 func NewWithUrl(username, password, base_url string) *client {
 	r := newRequestHandler()
-	c := &client{username, password, AccessTokenStruct{}, r, base_url}
+	c := &client{username, password, structs.AccessToken{}, r, base_url}
 	err := c.authenticate()
 	if err != nil {
 		c.handler.override = responseOverride{override: true, data: *err}
@@ -133,7 +133,7 @@ func (a *client) authenticate() *result {
 	}
 	dec := json.NewDecoder(bytes.NewBuffer(b))
 	if 200 <= statusCode && statusCode < 300 {
-		target := AccessTokenStruct{}
+		target := structs.AccessToken{}
 		err := dec.Decode(&target)
 		if err != nil {
 			return &result{body: nil, err: err}
@@ -145,8 +145,8 @@ func (a *client) authenticate() *result {
 	return &result{body: b, err: nil}
 }
 
-// Games queries the /games endpoint and returns a GameStructPaginated.
-func (a *client) Games(params Parameters) (GameStructPaginated, error) {
+// Games queries the /games endpoint and returns a structs.PaginatedGames.
+func (a *client) Games(params Parameters) (structs.PaginatedGames, error) {
 	if params == nil {
 		params = make(Parameters)
 	} else {
@@ -155,19 +155,19 @@ func (a *client) Games(params Parameters) (GameStructPaginated, error) {
 	params.Set("access_token", a.oauth.AccessToken)
 	result := <-a.handler.addRequest(a.base_url+games, params)
 	if result.err != nil {
-		return GameStructPaginated{}, result.err
+		return structs.PaginatedGames{}, result.err
 	}
 
-	target := GameStructPaginated{}
+	target := structs.PaginatedGames{}
 	err := json.Unmarshal(result.body, &target)
 	if err != nil {
-		return GameStructPaginated{}, err
+		return structs.PaginatedGames{}, err
 	}
 	return target, nil
 }
 
-// Series queries the /series endpoint and returns a SeriesStructPaginated.
-func (a *client) Series(params Parameters) (SeriesStructPaginated, error) {
+// Series queries the /series endpoint and returns a structs.PaginatedSeries.
+func (a *client) Series(params Parameters) (structs.PaginatedSeries, error) {
 	if params == nil {
 		params = make(Parameters)
 	} else {
@@ -177,16 +177,16 @@ func (a *client) Series(params Parameters) (SeriesStructPaginated, error) {
 	params.Set("access_token", a.oauth.AccessToken)
 	result := <-a.handler.addRequest(a.base_url+series, params)
 	if result.err != nil {
-		return SeriesStructPaginated{}, result.err
+		return structs.PaginatedSeries{}, result.err
 	}
 
-	target := SeriesStructPaginated{}
+	target := structs.PaginatedSeries{}
 	err := json.Unmarshal(result.body, &target)
 	return target, err
 }
 
-// SeriesById queries the /series/:id endpoint and returns a SeriesStruct.
-func (a *client) SeriesById(id int64, params Parameters) (SeriesStruct, error) {
+// SeriesById queries the /series/:id endpoint and returns a structs.Series.
+func (a *client) SeriesById(id int64, params Parameters) (structs.Series, error) {
 	sId := strconv.FormatInt(id, 10)
 	if params == nil {
 		params = make(Parameters)
@@ -197,16 +197,16 @@ func (a *client) SeriesById(id int64, params Parameters) (SeriesStruct, error) {
 	params.Set("access_token", a.oauth.AccessToken)
 	result := <-a.handler.addRequest(a.base_url+seriesById+sId, params)
 	if result.err != nil {
-		return SeriesStruct{}, result.err
+		return structs.Series{}, result.err
 	}
 
-	target := SeriesStruct{}
+	target := structs.Series{}
 	err := json.Unmarshal(result.body, &target)
 	return target, err
 }
 
-// MatchesById queries the /matches/:id endpoint and returns a MatchStruct.
-func (a *client) MatchesById(id int64, params Parameters) (MatchStruct, error) {
+// MatchesById queries the /matches/:id endpoint and returns a structs.Match.
+func (a *client) MatchesById(id int64, params Parameters) (structs.Match, error) {
 	sId := strconv.FormatInt(id, 10)
 	if params == nil {
 		params = make(Parameters)
@@ -217,16 +217,16 @@ func (a *client) MatchesById(id int64, params Parameters) (MatchStruct, error) {
 	params.Set("access_token", a.oauth.AccessToken)
 	result := <-a.handler.addRequest(a.base_url+matches+sId, params)
 	if result.err != nil {
-		return MatchStruct{}, result.err
+		return structs.Match{}, result.err
 	}
 
-	target := MatchStruct{}
+	target := structs.Match{}
 	err := json.Unmarshal(result.body, &target)
 	return target, err
 }
 
-// Tournaments queries the /tournaments endpoint and returns a list of TournamentStructPaginated.
-func (a *client) Tournaments(params Parameters) (TournamentStructPaginated, error) {
+// Tournaments queries the /tournaments endpoint and returns a list of structs.PaginatedTournaments.
+func (a *client) Tournaments(params Parameters) (structs.PaginatedTournaments, error) {
 	if params == nil {
 		params = make(Parameters)
 	} else {
@@ -236,16 +236,16 @@ func (a *client) Tournaments(params Parameters) (TournamentStructPaginated, erro
 	params.Set("access_token", a.oauth.AccessToken)
 	result := <-a.handler.addRequest(a.base_url+tournaments, params)
 	if result.err != nil {
-		return TournamentStructPaginated{}, result.err
+		return structs.PaginatedTournaments{}, result.err
 	}
 
-	target := TournamentStructPaginated{}
+	target := structs.PaginatedTournaments{}
 	err := json.Unmarshal(result.body, &target)
 	return target, err
 }
 
-// TournamentsById queries the /tournaments/:id endpoint and return a TournamentStruct.
-func (a *client) TournamentsById(id int64, params Parameters) (TournamentStruct, error) {
+// TournamentsById queries the /tournaments/:id endpoint and return a structs.Tournament.
+func (a *client) TournamentsById(id int64, params Parameters) (structs.Tournament, error) {
 	sId := strconv.FormatInt(id, 10)
 	if params == nil {
 		params = make(Parameters)
@@ -256,16 +256,16 @@ func (a *client) TournamentsById(id int64, params Parameters) (TournamentStruct,
 	params.Set("access_token", a.oauth.AccessToken)
 	result := <-a.handler.addRequest(a.base_url+tournamentsById+sId, params)
 	if result.err != nil {
-		return TournamentStruct{}, result.err
+		return structs.Tournament{}, result.err
 	}
 
-	target := TournamentStruct{}
+	target := structs.Tournament{}
 	err := json.Unmarshal(result.body, &target)
 	return target, err
 }
 
-// SubstagesById queries the /substages/:id endpoint and returns a SubstageStruct.
-func (a *client) SubstagesById(id int64, params Parameters) (SubstageStruct, error) {
+// SubstagesById queries the /substages/:id endpoint and returns a structs.Substage.
+func (a *client) SubstagesById(id int64, params Parameters) (structs.Substage, error) {
 	sId := strconv.FormatInt(id, 10)
 	if params == nil {
 		params = make(Parameters)
@@ -276,16 +276,16 @@ func (a *client) SubstagesById(id int64, params Parameters) (SubstageStruct, err
 	params.Set("access_token", a.oauth.AccessToken)
 	result := <-a.handler.addRequest(a.base_url+substages+sId, params)
 	if result.err != nil {
-		return SubstageStruct{}, result.err
+		return structs.Substage{}, result.err
 	}
 
-	target := SubstageStruct{}
+	target := structs.Substage{}
 	err := json.Unmarshal(result.body, &target)
 	return target, err
 }
 
-// Teams queries the /teams endpoint and returns a TeamsStructPaginated.
-func (a *client) Teams(params Parameters) (TeamStructPaginated, error) {
+// Teams queries the /teams endpoint and returns a structs.PaginatedTeams.
+func (a *client) Teams(params Parameters) (structs.PaginatedTeams, error) {
 	if params == nil {
 		params = make(Parameters)
 	} else {
@@ -295,16 +295,16 @@ func (a *client) Teams(params Parameters) (TeamStructPaginated, error) {
 	params.Set("access_token", a.oauth.AccessToken)
 	result := <-a.handler.addRequest(a.base_url+teams, params)
 	if result.err != nil {
-		return TeamStructPaginated{}, result.err
+		return structs.PaginatedTeams{}, result.err
 	}
 
-	target := TeamStructPaginated{}
+	target := structs.PaginatedTeams{}
 	err := json.Unmarshal(result.body, &target)
 	return target, err
 }
 
-// TeamsById queries the /teams/:id endpoint and return a TeamStruct.
-func (a *client) TeamsById(id int64, params Parameters) (TeamStruct, error) {
+// TeamsById queries the /teams/:id endpoint and return a structs.Team.
+func (a *client) TeamsById(id int64, params Parameters) (structs.Team, error) {
 	sId := strconv.FormatInt(id, 10)
 	if params == nil {
 		params = make(Parameters)
@@ -315,16 +315,16 @@ func (a *client) TeamsById(id int64, params Parameters) (TeamStruct, error) {
 	params.Set("access_token", a.oauth.AccessToken)
 	result := <-a.handler.addRequest(a.base_url+teamsById+sId, params)
 	if result.err != nil {
-		return TeamStruct{}, result.err
+		return structs.Team{}, result.err
 	}
 
-	target := TeamStruct{}
+	target := structs.Team{}
 	err := json.Unmarshal(result.body, &target)
 	return target, err
 }
 
 // Organisations queries the /organisations endpoint
-func (a *client) Organisations(params Parameters) (OrganisationStructPaginated, error) {
+func (a *client) Organisations(params Parameters) (structs.PaginatedOrganisations, error) {
 	if params == nil {
 		params = make(Parameters)
 	} else {
@@ -334,32 +334,32 @@ func (a *client) Organisations(params Parameters) (OrganisationStructPaginated, 
 	params.Set("access_token", a.oauth.AccessToken)
 	result := <-a.handler.addRequest(a.base_url+organisations, params)
 	if result.err != nil {
-		return OrganisationStructPaginated{}, result.err
+		return structs.PaginatedOrganisations{}, result.err
 	}
 
-	target := OrganisationStructPaginated{}
+	target := structs.PaginatedOrganisations{}
 	err := json.Unmarshal(result.body, &target)
 	return target, err
 }
 
 // OrganisationsById queries the /organisations/:id endpoint
-func (a *client) OrganisationsById(id int64) (OrganisationStruct, error) {
+func (a *client) OrganisationsById(id int64) (structs.Organisation, error) {
 	sId := strconv.FormatInt(id, 10)
 	params := make(Parameters)
 
 	params.Set("access_token", a.oauth.AccessToken)
 	result := <-a.handler.addRequest(a.base_url+organisationsById+sId, params)
 	if result.err != nil {
-		return OrganisationStruct{}, result.err
+		return structs.Organisation{}, result.err
 	}
 
-	target := OrganisationStruct{}
+	target := structs.Organisation{}
 	err := json.Unmarshal(result.body, &target)
 	return target, err
 }
 
-// Players queries the /players endpoint and returns PlayerStructPaginated.
-func (a *client) Players(params Parameters) (PlayerStructPaginated, error) {
+// Players queries the /players endpoint and returns structs.PaginatedPlayers.
+func (a *client) Players(params Parameters) (structs.PaginatedPlayers, error) {
 	if params == nil {
 		params = make(Parameters)
 	} else {
@@ -369,16 +369,16 @@ func (a *client) Players(params Parameters) (PlayerStructPaginated, error) {
 	params.Set("access_token", a.oauth.AccessToken)
 	result := <-a.handler.addRequest(a.base_url+players, params)
 	if result.err != nil {
-		return PlayerStructPaginated{}, result.err
+		return structs.PaginatedPlayers{}, result.err
 	}
 
-	target := PlayerStructPaginated{}
+	target := structs.PaginatedPlayers{}
 	err := json.Unmarshal(result.body, &target)
 	return target, err
 }
 
-// PlayersById queries the /players/:id endpoint and returns a PlayerStruct.
-func (a *client) PlayersById(id int64, params Parameters) (PlayerStruct, error) {
+// PlayersById queries the /players/:id endpoint and returns a structs.Player.
+func (a *client) PlayersById(id int64, params Parameters) (structs.Player, error) {
 	sId := strconv.FormatInt(id, 10)
 	if params == nil {
 		params = make(Parameters)
@@ -389,16 +389,16 @@ func (a *client) PlayersById(id int64, params Parameters) (PlayerStruct, error) 
 	params.Set("access_token", a.oauth.AccessToken)
 	result := <-a.handler.addRequest(a.base_url+playersById+sId, params)
 	if result.err != nil {
-		return PlayerStruct{}, result.err
+		return structs.Player{}, result.err
 	}
 
-	target := PlayerStruct{}
+	target := structs.Player{}
 	err := json.Unmarshal(result.body, &target)
 	return target, err
 }
 
-// RostersById queries the /rosters/:id endpoint and returns a RosterStruct.
-func (a *client) RostersById(id int64, params Parameters) (RosterStruct, error) {
+// RostersById queries the /rosters/:id endpoint and returns a structs.Roster.
+func (a *client) RostersById(id int64, params Parameters) (structs.Roster, error) {
 	sId := strconv.FormatInt(id, 10)
 	if params == nil {
 		params = make(Parameters)
@@ -409,17 +409,17 @@ func (a *client) RostersById(id int64, params Parameters) (RosterStruct, error) 
 	params.Set("access_token", a.oauth.AccessToken)
 	result := <-a.handler.addRequest(a.base_url+rosters+sId, params)
 	if result.err != nil {
-		return RosterStruct{}, result.err
+		return structs.Roster{}, result.err
 	}
 
-	target := RosterStruct{}
+	target := structs.Roster{}
 	err := json.Unmarshal(result.body, &target)
 	return target, err
 }
 
 // Search queries the /search endpoint with the given query and returns a list of
-// SearchResultStruct.
-func (a *client) Search(query string, params Parameters) ([]SearchResultStruct, error) {
+// structs.SearchResult.
+func (a *client) Search(query string, params Parameters) ([]structs.SearchResult, error) {
 	if params == nil {
 		params = make(Parameters)
 	} else {
@@ -433,13 +433,13 @@ func (a *client) Search(query string, params Parameters) ([]SearchResultStruct, 
 		return nil, result.err
 	}
 
-	target := []SearchResultStruct{}
+	target := []structs.SearchResult{}
 	err := json.Unmarshal(result.body, &target)
 	return target, err
 }
 
-// Incidents queries the /incidents endpoint and returns an IncidentStructPaginated.
-func (a *client) Incidents(params Parameters) (IncidentStructPaginated, error) {
+// Incidents queries the /incidents endpoint and returns an structs.PaginatedIncidents.
+func (a *client) Incidents(params Parameters) (structs.PaginatedIncidents, error) {
 	if params == nil {
 		params = make(Parameters)
 	} else {
@@ -449,26 +449,26 @@ func (a *client) Incidents(params Parameters) (IncidentStructPaginated, error) {
 	params.Set("access_token", a.oauth.AccessToken)
 	result := <-a.handler.addRequest(a.base_url+incidents, params)
 	if result.err != nil {
-		return IncidentStructPaginated{}, result.err
+		return structs.PaginatedIncidents{}, result.err
 	}
 
-	target := IncidentStructPaginated{}
+	target := structs.PaginatedIncidents{}
 	err := json.Unmarshal(result.body, &target)
 	return target, err
 }
 
 // IncidentBySeriesId queries the /incidents/:series_id endpoint and returns a
-// SeriesIncidentsStruct.
-func (a *client) IncidentsBySeriesId(id int64) (SeriesIncidentsStruct, error) {
+// structs.SeriesIncidents.
+func (a *client) IncidentsBySeriesId(id int64) (structs.SeriesIncidents, error) {
 	sId := strconv.FormatInt(id, 10)
 	params := make(Parameters)
 	params.Set("access_token", a.oauth.AccessToken)
 	result := <-a.handler.addRequest(a.base_url+incidentsBySeries+sId, params)
 	if result.err != nil {
-		return SeriesIncidentsStruct{}, result.err
+		return structs.SeriesIncidents{}, result.err
 	}
 
-	target := SeriesIncidentsStruct{}
+	target := structs.SeriesIncidents{}
 	err := json.Unmarshal(result.body, &target)
 	return target, err
 }

--- a/examples/calendar/calendar.go
+++ b/examples/calendar/calendar.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/AbiosGaming/go-sdk-v2"
+	"github.com/AbiosGaming/go-sdk-v2/v3"
 )
 
 // currentCalendar holds what we respond to our users

--- a/examples/concurrent/concurrent.go
+++ b/examples/concurrent/concurrent.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/AbiosGaming/go-sdk-v2"
+	"github.com/AbiosGaming/go-sdk-v2/v3"
 )
 
 func main() {

--- a/examples/series_every_minute/series_every_minute.go
+++ b/examples/series_every_minute/series_every_minute.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/AbiosGaming/go-sdk-v2"
+	"github.com/AbiosGaming/go-sdk-v2/v3"
 )
 
 func main() {

--- a/examples/winrates/winrates.go
+++ b/examples/winrates/winrates.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/AbiosGaming/go-sdk-v2"
+	"github.com/AbiosGaming/go-sdk-v2/v3"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/AbiosGaming/go-sdk-v2/v3
+
+go 1.12

--- a/http_wrapper.go
+++ b/http_wrapper.go
@@ -2,6 +2,7 @@ package abios
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -52,6 +53,13 @@ func apiCall(req *http.Request) (int, []byte, error) {
 		if err != nil {
 			return 0, nil, err
 		}
+
+		// We didn't manage to actually unmarshal into the struct. Create an error with what
+		// we have
+		if target.ErrorDescription == "" {
+			return resp.StatusCode, body, fmt.Errorf(body)
+		}
+
 		return resp.StatusCode, nil, target
 	}
 

--- a/http_wrapper.go
+++ b/http_wrapper.go
@@ -57,7 +57,7 @@ func apiCall(req *http.Request) (int, []byte, error) {
 		// We didn't manage to actually unmarshal into the struct. Create an error with what
 		// we have
 		if target.ErrorDescription == "" {
-			return resp.StatusCode, body, fmt.Errorf(body)
+			return resp.StatusCode, body, fmt.Errorf(string(body))
 		}
 
 		return resp.StatusCode, nil, target

--- a/http_wrapper.go
+++ b/http_wrapper.go
@@ -44,15 +44,16 @@ func apiCall(req *http.Request) (int, []byte, error) {
 		return 0, nil, err
 	}
 
-	var target *structs.ErrorStruct = nil
 	// If it is an error try to unmarshal it into the ErrorStruct.
 	// 410 still returns data in the expected format
 	if resp.StatusCode != 410 && (resp.StatusCode < 200 || 300 <= resp.StatusCode) {
-		err := json.Unmarshal(body, target)
+		target := structs.ErrorStruct{}
+		err := json.Unmarshal(body, &target)
 		if err != nil {
 			return 0, nil, err
 		}
+		return resp.StatusCode, nil, target
 	}
 
-	return resp.StatusCode, body, target
+	return resp.StatusCode, body, nil
 }

--- a/http_wrapper.go
+++ b/http_wrapper.go
@@ -45,10 +45,10 @@ func apiCall(req *http.Request) (int, []byte, error) {
 		return 0, nil, err
 	}
 
-	// If it is an error try to unmarshal it into the ErrorStruct.
+	// If it is an error try to unmarshal it into a structs.Error.
 	// 410 still returns data in the expected format
 	if resp.StatusCode != 410 && (resp.StatusCode < 200 || 300 <= resp.StatusCode) {
-		target := structs.ErrorStruct{}
+		target := structs.Error{}
 		err := json.Unmarshal(body, &target)
 		if err != nil {
 			return 0, nil, err
@@ -56,7 +56,7 @@ func apiCall(req *http.Request) (int, []byte, error) {
 
 		// We didn't manage to actually unmarshal into the struct. Create an error with what
 		// we have
-		if target.ErrorDescription == "" {
+		if target.ErrorMessage == "" {
 			return resp.StatusCode, body, fmt.Errorf(string(body))
 		}
 

--- a/http_wrapper.go
+++ b/http_wrapper.go
@@ -45,8 +45,9 @@ func apiCall(req *http.Request) (int, []byte, error) {
 	}
 
 	var target *structs.ErrorStruct = nil
-	// If it is an error try to unmarshal it into the ErrorStruct
-	if resp.StatusCode < 200 || 300 <= resp.StatusCode {
+	// If it is an error try to unmarshal it into the ErrorStruct.
+	// 410 still returns data in the expected format
+	if resp.StatusCode != 410 && (resp.StatusCode < 200 || 300 <= resp.StatusCode) {
 		err := json.Unmarshal(body, target)
 		if err != nil {
 			return 0, nil, err

--- a/http_wrapper.go
+++ b/http_wrapper.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/AbiosGaming/go-sdk-v2/structs"
+	"github.com/AbiosGaming/go-sdk-v2/v3/structs"
 )
 
 // performRequest creates the request, sends it and return the response's statuscode along

--- a/request_handler.go
+++ b/request_handler.go
@@ -52,6 +52,7 @@ type request struct {
 type result struct {
 	statuscode int
 	body       []byte
+	err        error
 }
 
 // requestHandler buffers requests and sends them out at a user-specified rate.
@@ -182,7 +183,7 @@ func (r *requestHandler) dispatcher() {
 								if r.override.override {
 									currentRequest.ch <- r.override.data
 								} else {
-									re.statuscode, re.body = performRequest(currentRequest.url, currentRequest.params)
+									re.statuscode, re.body, re.err = performRequest(currentRequest.url, currentRequest.params)
 									currentRequest.ch <- re
 								}
 

--- a/request_handler.go
+++ b/request_handler.go
@@ -50,9 +50,8 @@ type request struct {
 
 // result hold the returned data of an API request.
 type result struct {
-	statuscode int
-	body       []byte
-	err        error
+	body []byte
+	err  error
 }
 
 // requestHandler buffers requests and sends them out at a user-specified rate.
@@ -183,7 +182,7 @@ func (r *requestHandler) dispatcher() {
 								if r.override.override {
 									currentRequest.ch <- r.override.data
 								} else {
-									re.statuscode, re.body, re.err = performRequest(currentRequest.url, currentRequest.params)
+									_, re.body, re.err = performRequest(currentRequest.url, currentRequest.params)
 									currentRequest.ch <- re
 								}
 

--- a/structs/access_token.go
+++ b/structs/access_token.go
@@ -1,7 +1,7 @@
 package structs
 
-// AccessTokenStruct holds information about an access token.
-type AccessTokenStruct struct {
+// AccessToken holds information about an access token.
+type AccessToken struct {
 	AccessToken string `json:"access_token"`
 	TokenType   string `json:"token_type"`
 	ExpiresIn   int64  `json:"expires_in"`

--- a/structs/bracket_position.go
+++ b/structs/bracket_position.go
@@ -1,9 +1,9 @@
 package structs
 
 // BracketPosition represents a Series position in a Substages bracket.
-type BracketPositionStruct struct {
-	Part    string        `json:"part,omitempty"`
-	Col     int64         `json:"col"`
-	Offset  int64         `json:"offset"`
-	Seeding SeedingStruct `json:"seeding,omitempty"`
+type BracketPosition struct {
+	Part    string  `json:"part,omitempty"`
+	Col     int64   `json:"col"`
+	Offset  int64   `json:"offset"`
+	Seeding Seeding `json:"seeding,omitempty"`
 }

--- a/structs/caster.go
+++ b/structs/caster.go
@@ -1,12 +1,12 @@
 package structs
 
-// CasterStruct represents an individual shoutcaster, casting a Series.
-type CasterStruct struct {
-	Id      int64         `json:"id,omitempty"`
-	Name    string        `json:"name,omitempty"`
-	Type    *int64        `json:"type,omitempty"`
-	Url     string        `json:"url,omitempty"`
-	Primary bool          `json:"primary,omitmepty"`
-	Stream  *StreamStruct `json:"stream,omitempty"`
-	Country CountryStruct `json:"country,omitempty"`
+// Caster represents an individual shoutcaster, casting a Series.
+type Caster struct {
+	Id      int64   `json:"id,omitempty"`
+	Name    string  `json:"name,omitempty"`
+	Type    *int64  `json:"type,omitempty"`
+	Url     string  `json:"url,omitempty"`
+	Primary bool    `json:"primary,omitmepty"`
+	Stream  *Stream `json:"stream,omitempty"`
+	Country Country `json:"country,omitempty"`
 }

--- a/structs/country.go
+++ b/structs/country.go
@@ -1,10 +1,9 @@
 package structs
 
-/* CountryStruct hold information about a country, nationality or language
- * associated with a resource.
- */
-type CountryStruct struct {
-	Name      string              `json:"name,omitempty"`
-	ShortName string              `json:"short_name,omitempty"`
-	Images    CountryImagesStruct `json:"images,omitempty"`
+// Country hold information about a country, nationality or language
+// associated with a resource.
+type Country struct {
+	Name      string        `json:"name,omitempty"`
+	ShortName string        `json:"short_name,omitempty"`
+	Images    CountryImages `json:"images,omitempty"`
 }

--- a/structs/default_roster.go
+++ b/structs/default_roster.go
@@ -1,10 +1,9 @@
 package structs
 
-/* DefaultRosterStruct represents the time period(s) when a Roster has been a Team's
- * main roster or line-up.
- */
-type DefaultRosterStruct struct {
-	From   string       `json:"from,omitempty"`
-	To     *string      `json:"to,omitempty"`
-	Roster RosterStruct `json:"roster,omitempty"`
+// DefaultRoster represents the time period(s) when a Roster has been a Team's
+// main roster or line-up.
+type DefaultRoster struct {
+	From   string  `json:"from,omitempty"`
+	To     *string `json:"to,omitempty"`
+	Roster Roster  `json:"roster,omitempty"`
 }

--- a/structs/error.go
+++ b/structs/error.go
@@ -6,12 +6,20 @@ import (
 
 // ErrorStruct represents an error response from the API.
 type ErrorStruct struct {
-	Error            string `json:"error,omitempty"`
+	ErrorMessage     string `json:"error,omitempty"`
 	ErrorCode        int64  `json:"error_code,omitempty"`
 	ErrorDescription string `json:"error_description,omitempty"`
 }
 
 func (e ErrorStruct) String() (s string) {
+	return e.format()
+}
+
+func (e ErrorStruct) Error() (s string) {
+	return e.format()
+}
+
+func (e ErrorStruct) format() (s string) {
 	s = fmt.Sprintf("error: %v, error_code: %v, error_decription: %v",
 		e.Error, e.ErrorCode, e.ErrorDescription)
 	return s

--- a/structs/error.go
+++ b/structs/error.go
@@ -4,22 +4,22 @@ import (
 	"fmt"
 )
 
-// ErrorStruct represents an error response from the API.
-type ErrorStruct struct {
+// Error represents an error response from the API.
+type Error struct {
 	ErrorMessage     string `json:"error,omitempty"`
 	ErrorCode        int64  `json:"error_code,omitempty"`
 	ErrorDescription string `json:"error_description,omitempty"`
 }
 
-func (e ErrorStruct) String() (s string) {
+func (e Error) String() (s string) {
 	return e.format()
 }
 
-func (e ErrorStruct) Error() (s string) {
+func (e Error) Error() (s string) {
 	return e.format()
 }
 
-func (e ErrorStruct) format() (s string) {
+func (e Error) format() (s string) {
 	s = fmt.Sprintf("error: %v, error_code: %v, error_decription: %v",
 		e.Error, e.ErrorCode, e.ErrorDescription)
 	return s

--- a/structs/error.go
+++ b/structs/error.go
@@ -21,6 +21,6 @@ func (e Error) Error() (s string) {
 
 func (e Error) format() (s string) {
 	s = fmt.Sprintf("error: %v, error_code: %v, error_decription: %v",
-		e.Error, e.ErrorCode, e.ErrorDescription)
+		e.ErrorMessage, e.ErrorCode, e.ErrorDescription)
 	return s
 }

--- a/structs/forfeit.go
+++ b/structs/forfeit.go
@@ -1,0 +1,5 @@
+package structs
+
+// Forfeit contains two items with roster ids as keys mapping to a boolean value
+// describing whether the roster has forfeited or not.
+type Forfeit map[string]bool

--- a/structs/forfeit_struct.go
+++ b/structs/forfeit_struct.go
@@ -1,6 +1,0 @@
-package structs
-
-/* ForfeitStruct contains two items with roster ids as keys mapping to a boolean value
- * describing whether the roster has forfeited or not.
- */
-type ForfeitStruct map[string]bool

--- a/structs/game.go
+++ b/structs/game.go
@@ -3,19 +3,19 @@ Package structs contains the structs AbiosGaming/sdk uses to unmarshal JSON.
 */
 package structs
 
-// GameStructPaginated holds a list of GameStruct as well as information about pages.
-type GameStructPaginated struct {
-	LastPage    int64        `json:"last_page,omitempty"`
-	CurrentPage int64        `json:"current_page,omitempty"`
-	Data        []GameStruct `json:"data,omitempty"`
+// PaginatedGames holds a list of Game as well as information about pages.
+type PaginatedGames struct {
+	LastPage    int64  `json:"last_page,omitempty"`
+	CurrentPage int64  `json:"current_page,omitempty"`
+	Data        []Game `json:"data,omitempty"`
 }
 
-// GameStruct represents the actual game being played in a Series
-type GameStruct struct {
-	Id        int64            `json:"id,omitempty"`
-	Title     string           `json:"title,omitempty"`
-	LongTitle string           `json:"long_title,omitempty"`
-	DeletedAt *string          `json:"deleted_at"` // Datettime
-	Images    GameImagesStruct `json:"images,omitempty"`
-	Color     string           `json:"color,omitempty"`
+// Game represents the actual game being played in a Series
+type Game struct {
+	Id        int64      `json:"id,omitempty"`
+	Title     string     `json:"title,omitempty"`
+	LongTitle string     `json:"long_title,omitempty"`
+	DeletedAt *string    `json:"deleted_at"` // Datettime
+	Images    GameImages `json:"images,omitempty"`
+	Color     string     `json:"color,omitempty"`
 }

--- a/structs/hero.go
+++ b/structs/hero.go
@@ -1,6 +1,6 @@
 package structs
 
-type HeroStruct struct {
+type Hero struct {
 	Name      string `json:"name"`
 	Attribute string `json:"attribute"`
 	Images    struct {

--- a/structs/images.go
+++ b/structs/images.go
@@ -1,14 +1,14 @@
 package structs
 
-// GameImagesStruct represents the different keys for images a GameStruct can contain
-type GameImagesStruct struct {
+// GameImages represents the different keys for images a Game can contain
+type GameImages struct {
 	Square    string `json:"square,omitempty"`
 	Circle    string `json:"circle,omitempty"`
 	Rectangle string `json:"rectangle,omitempty"`
 }
 
-// TournamentImagesStruct represents the different keys for images a TournamentStruct can contain
-type TournamentImagesStruct struct {
+// TournamentImages represents the different keys for images a Tournament can contain
+type TournamentImages struct {
 	Default   string `json:"default,omitempty"`
 	Thumbnail string `json:"thumbnail,omitempty"`
 	Banner    string `json:"banner,omitempty"`
@@ -16,39 +16,39 @@ type TournamentImagesStruct struct {
 	Fallback  bool   `json:"fallback"`
 }
 
-// TeamImagesStruct represents the different keys for images a TeamStruct can contain
-type TeamImagesStruct struct {
+// TeamImages represents the different keys for images a Team can contain
+type TeamImages struct {
 	Default   string `json:"default,omitempty"`
 	Thumbnail string `json:"thumbnail,omitempty"`
 	Fallback  bool   `json:"fallback"`
 }
 
-// PlayerImagesStruct represents the different keys for images a PlayerStruct can contain
-type PlayerImagesStruct struct {
+// PlayerImages represents the different keys for images a Player can contain
+type PlayerImages struct {
 	Default   string `json:"default,omitempty"`
 	Thumbnail string `json:"thumbnail,omitempty"`
 	Fallback  bool   `json:"fallback"`
 }
 
-// RaceImagesStruct represents the different keys for images a RaceStruct can contain
-type RaceImagesStruct struct {
+// RaceImages represents the different keys for images a Race can contain
+type RaceImages struct {
 	Default   string `json:"default,omitempty"`
 	Thumbnail string `json:"thumbnail,omitempty"`
 }
 
-// StreamImagesStruct represents the different keys for images a StreamStruct can contain
-type StreamImagesStruct struct {
+// StreamImages represents the different keys for images a Stream can contain
+type StreamImages struct {
 	UserLogo string `json:"user_logo,omitempty"`
 	Preview  string `json:"preview,omitempty"`
 }
 
-// PlatformImagesStruct represents the different keys for images a PlatformStruct can contain
-type PlatformImagesStruct struct {
+// PlatformImages represents the different keys for images a Platform can contain
+type PlatformImages struct {
 	Default string `json:"default,omitempty"`
 }
 
-// CountryImagesStruct represents the different keys for images a CountryStruct can contain
-type CountryImagesStruct struct {
+// CountryImages represents the different keys for images a Country can contain
+type CountryImages struct {
 	Default   string `json:"default,omitempty"`
 	Thumbnail string `json:"thumbnail,omitempty"`
 }

--- a/structs/incident.go
+++ b/structs/incident.go
@@ -1,14 +1,14 @@
 package structs
 
-// IncidentStructPaginated holds a list of IncidentStruct as well as information about pages
-type IncidentStructPaginated struct {
-	LastPage    int64            `json:"last_page,omitempty"`
-	CurrentPage int64            `json:"current_page,omitempty"`
-	Data        []IncidentStruct `json:"data"`
+// PaginatedIncidents holds a list of Incident as well as information about pages
+type PaginatedIncidents struct {
+	LastPage    int64      `json:"last_page,omitempty"`
+	CurrentPage int64      `json:"current_page,omitempty"`
+	Data        []Incident `json:"data"`
 }
 
-// IncidentStruct represents an incident.
-type IncidentStruct struct {
+// Incident represents an incident.
+type Incident struct {
 	SeriesId   int64   `json:"series_id,omitempty"`
 	MatchId    *int64  `json:"match_id,omitempty"`
 	Comment    string  `json:"comment,omitempty"`

--- a/structs/item.go
+++ b/structs/item.go
@@ -1,6 +1,6 @@
 package structs
 
-type DotaItemStruct struct {
+type DotaItem struct {
 	Image struct {
 		Default   string `json:"default"`
 		Thumbnail string `json:"thumbnail"`
@@ -8,7 +8,7 @@ type DotaItemStruct struct {
 	Name string `json:"name"`
 }
 
-type LolItemStruct struct {
+type LolItem struct {
 	Name       string `json:"name"`
 	ExternalId int64  `json:"external_id"`
 	Image      struct {

--- a/structs/map.go
+++ b/structs/map.go
@@ -1,9 +1,9 @@
 package structs
 
-// MapStruct represents the map being played in a Match
-type MapStruct struct {
-	Id       int64      `json:"id"`
-	Name     string     `json:"name,omitempty"`
-	Official bool       `json:"official"`
-	Game     GameStruct `json:"game,omitempty"`
+// Map represents the map being played in a Match
+type Map struct {
+	Id       int64  `json:"id"`
+	Name     string `json:"name,omitempty"`
+	Official bool   `json:"official"`
+	Game     Game   `json:"game,omitempty"`
 }

--- a/structs/match.go
+++ b/structs/match.go
@@ -4,28 +4,28 @@ import (
 	"encoding/json"
 )
 
-// MatchStruct represents an actual map being played between two rosters.
-type MatchStruct struct {
-	Id           int64                  `json:"id,omitempty"`
-	Order        int64                  `json:"order,omitempty"`
-	Winner       *int64                 `json:"winner"`
-	Map          *MapStruct             `json:"map,omitempty"`
-	DeletedAt    *string                `json:"deleted_at"`
-	Game         GameStruct             `json:"game"`
-	HasPbpStats  bool                   `json:"has_pbpstats"`
-	Scores       *ScoresStruct          `json:"scores"`
-	Forfeit      ForfeitStruct          `json:"forfeit,omitempty"`
-	Seeding      SeedingStruct          `json:"seeding,omitempty"`
-	Rosters      []RosterStruct         `json:"rosters"`
-	Performance  MatchPerformanceStruct `json:"performance,omitempty"`
-	MatchSummary MatchSummaryStruct     `json:"match_summary"` // Play by Play
+// Match represents an actual map being played between two rosters.
+type Match struct {
+	Id           int64            `json:"id,omitempty"`
+	Order        int64            `json:"order,omitempty"`
+	Winner       *int64           `json:"winner"`
+	Map          *Map             `json:"map,omitempty"`
+	DeletedAt    *string          `json:"deleted_at"`
+	Game         Game             `json:"game"`
+	HasPbpStats  bool             `json:"has_pbpstats"`
+	Scores       *Scores          `json:"scores"`
+	Forfeit      Forfeit          `json:"forfeit,omitempty"`
+	Seeding      Seeding          `json:"seeding,omitempty"`
+	Rosters      []Roster         `json:"rosters"`
+	Performance  MatchPerformance `json:"performance,omitempty"`
+	MatchSummary MatchSummary     `json:"match_summary"` // Play by Play
 }
 
 // avoid recursion when unmarshaling
-type matchStruct MatchStruct
+type match Match
 
 // We need to unmarshal match_summary into the game-specific struct
-func (m *MatchStruct) UnmarshalJSON(data []byte) error {
+func (m *Match) UnmarshalJSON(data []byte) error {
 	// find the outer-most keys
 	var partial map[string]json.RawMessage
 	if err := json.Unmarshal(data, &partial); err != nil {
@@ -37,7 +37,7 @@ func (m *MatchStruct) UnmarshalJSON(data []byte) error {
 	delete(partial, "match_summary")
 	data, _ = json.Marshal(partial)
 
-	var mm matchStruct
+	var mm match
 	if err := json.Unmarshal(data, &mm); err != nil {
 		return err
 	}
@@ -70,6 +70,6 @@ func (m *MatchStruct) UnmarshalJSON(data []byte) error {
 		}
 	}
 
-	*m = MatchStruct(mm)
+	*m = Match(mm)
 	return nil
 }

--- a/structs/match_performance.go
+++ b/structs/match_performance.go
@@ -2,31 +2,31 @@ package structs
 
 import "encoding/json"
 
-// MatchPerformanceStruct is associated with a Match and contains performance information
+// MatchPerformance is associated with a Match and contains performance information
 // about the Rosters with respect to the specific map.
-type MatchPerformanceStruct struct {
-	Winrate MatchWinrateStruct `json:"winrate,omitempty"`
+type MatchPerformance struct {
+	Winrate MatchWinrate `json:"winrate,omitempty"`
 }
 
-// MatchWinrateStruct holds the top-level keys for winrate statistics.
-type MatchWinrateStruct struct {
-	Overall *MatchWinrateOverallStruct `json:"over_all"`
-	PerMap  []MatchWinratePerMapStruct `json:"per_map"`
+// MatchWinrate holds the top-level keys for winrate statistics.
+type MatchWinrate struct {
+	Overall *MatchWinrateOverall `json:"over_all"`
+	PerMap  []MatchWinratePerMap `json:"per_map"`
 }
 
-// MatchWinrateOverallStruct holds information about the summarized performance statistics.
-type MatchWinrateOverallStruct struct {
+// MatchWinrateOverall holds information about the summarized performance statistics.
+type MatchWinrateOverall struct {
 	History int64              `json:"history,omitempty"`
 	Rosters map[string]float64 `json:"-"`
 }
 
-type _MatchWinrateOverallStruct MatchWinrateOverallStruct
+type _MatchWinrateOverall MatchWinrateOverall
 
-func (m *MatchWinrateOverallStruct) UnmarshalJSON(b []byte) (err error) {
-	foo := _MatchWinrateOverallStruct{}
+func (m *MatchWinrateOverall) UnmarshalJSON(b []byte) (err error) {
+	foo := _MatchWinrateOverall{}
 
 	if err = json.Unmarshal(b, &foo); err == nil {
-		*m = MatchWinrateOverallStruct(foo)
+		*m = MatchWinrateOverall(foo)
 	}
 
 	stuff := make(map[string]interface{})
@@ -42,20 +42,20 @@ func (m *MatchWinrateOverallStruct) UnmarshalJSON(b []byte) (err error) {
 	return err
 }
 
-// MatchWinratePerMapStruct breaks down the winrate statistics per Map.
-type MatchWinratePerMapStruct struct {
-	Map     MapStruct          `json:"map,omitempty"`
+// MatchWinratePerMap breaks down the winrate statistics per Map.
+type MatchWinratePerMap struct {
+	Map     Map                `json:"map,omitempty"`
 	History int64              `json:"history,omitempty"`
 	Rosters map[string]float64 `json:"-"`
 }
 
-type _MatchWinratePerMapStruct MatchWinratePerMapStruct
+type _MatchWinratePerMap MatchWinratePerMap
 
-func (m *MatchWinratePerMapStruct) UnmarshalJSON(b []byte) (err error) {
-	foo := _MatchWinratePerMapStruct{}
+func (m *MatchWinratePerMap) UnmarshalJSON(b []byte) (err error) {
+	foo := _MatchWinratePerMap{}
 
 	if err = json.Unmarshal(b, &foo); err == nil {
-		*m = MatchWinratePerMapStruct(foo)
+		*m = MatchWinratePerMap(foo)
 	}
 
 	stuff := make(map[string]interface{})

--- a/structs/match_summary.go
+++ b/structs/match_summary.go
@@ -1,9 +1,9 @@
 package structs
 
-// MatchSummaryStruct holds information about play by play statistics for a certain match.
-type MatchSummaryStruct interface{}
+// MatchSummary holds information about play by play statistics for a certain match.
+type MatchSummary interface{}
 
-// CsMatchSummaryStruct is the summarization of a CS:GO match.
+// CsMatchSummary is the summarization of a CS:GO match.
 type CsMatchSummary struct {
 	Home        int64 `json:"home"`
 	Away        int64 `json:"away"`
@@ -19,35 +19,35 @@ type CsMatchSummary struct {
 		Winner     int64  `json:"winner"`
 		WinReason  string `json:"win_reason"`
 		BombEvents []struct {
-			Type       string    `json:"type"`
-			PlayerId   int64     `json:"player_id"`
-			RoundClock int64     `json:"round_clock"`
-			Pos        PosStruct `json:"pos"`
+			Type       string `json:"type"`
+			PlayerId   int64  `json:"player_id"`
+			RoundClock int64  `json:"round_clock"`
+			Pos        Pos    `json:"pos"`
 		} `json:"bomb_events"`
 		Kills []struct {
 			RoundClock int64 `json:"round_clock"`
 			Damage     int64 `json:"damage"`
 			Attacker   struct {
-				PlayerId int64     `json:"player_id"`
-				Pos      PosStruct `json:"pos"`
+				PlayerId int64 `json:"player_id"`
+				Pos      Pos   `json:"pos"`
 			} `json:"attacker"`
 			Victim struct {
-				PlayerId int64     `json:"player_id"`
-				Pos      PosStruct `json:"pos"`
+				PlayerId int64 `json:"player_id"`
+				Pos      Pos   `json:"pos"`
 			} `json:"victim"`
-			Assists  *int64       `json:"assist"`
-			Weapon   WeaponStruct `json:"weapon"`
-			HitGroup string       `json:"hit_group"`
+			Assists  *int64 `json:"assist"`
+			Weapon   Weapon `json:"weapon"`
+			HitGroup string `json:"hit_group"`
 		} `json:"kills"`
 		PlayerStats struct {
-			TSide  []RoundPlayerStatsStruct `json:"t_side"`
-			CtSide []RoundPlayerStatsStruct `json:"ct_side"`
+			TSide  []RoundPlayerStats `json:"t_side"`
+			CtSide []RoundPlayerStats `json:"ct_side"`
 		} `json:"player_stats"`
 	} `json:"rounds"`
 }
 
-// RoundPlayerStatsStruct reflects how well a player performed in a round.
-type RoundPlayerStatsStruct struct {
+// RoundPlayerStats reflects how well a player performed in a round.
+type RoundPlayerStats struct {
 	PlayerId int64   `json:"player_id"`
 	DmgGiven float64 `json:"dmg_given"`
 	DmgTaken float64 `json:"dmg_taken"`
@@ -60,8 +60,8 @@ type RoundPlayerStatsStruct struct {
 	} `json:"accuracy"`
 }
 
-// PosStruct hold x, y and z coordinates.
-type PosStruct struct {
+// Pos hold x, y and z coordinates.
+type Pos struct {
 	X float64 `json:"x"`
 	Y float64 `json:"y"`
 	Z float64 `json:"z"`
@@ -76,16 +76,16 @@ type CsScoreBoardEntry struct {
 	Adr      float64 `json:"adr"`
 }
 
-// DotaMatchSummaryStruct is the summarization of a Dota match.
+// DotaMatchSummary is the summarization of a Dota match.
 type DotaMatchSummary struct {
 	RadiantRoster int64 `json:"radiant_roster"`
 	DireRoster    int64 `json:"dire_roster"`
 	MatchLength   int64 `json:"match_length"`
 	DraftSeq      []struct {
-		Order    int64      `json:"order"`
-		Type     string     `json:"type"`
-		RosterId int64      `json:"roster_id"`
-		Hero     HeroStruct `json:"hero"`
+		Order    int64  `json:"order"`
+		Type     string `json:"type"`
+		RosterId int64  `json:"roster_id"`
+		Hero     Hero   `json:"hero"`
 	} `json:"draft_seq"`
 	FirstBlood struct {
 		Killer int64 `json:"killer"`
@@ -98,15 +98,15 @@ type DotaMatchSummary struct {
 		AtTime  int64   `json:"at_time"`
 		Assists []int64 `json:"assists"`
 	} `json:"kills"`
-	StructureDest []struct {
-		Killer        int64  `json:"killer"`
-		StructureType string `json:"structure_type"`
-		StructurePos  string `json:"structure_pos"`
-		AtTime        int64  `json:"at_time"`
+	ureDest []struct {
+		Killer  int64  `json:"killer"`
+		ureType string `json:"structure_type"`
+		urePos  string `json:"structure_pos"`
+		AtTime  int64  `json:"at_time"`
 	} `json:"structure_dest"`
 	PlayerStats []struct {
 		PlayerId    int64            `json:"player_id"`
-		Hero        HeroStruct       `json:"hero"`
+		Hero        Hero             `json:"hero"`
 		Kills       int64            `json:"kills"`
 		Deaths      int64            `json:"deaths"`
 		Assists     int64            `json:"assists"`
@@ -137,25 +137,25 @@ type DotaMatchSummary struct {
 		} `json:"hero_healing"`
 		Items struct {
 			Inventory struct {
-				Slot1 DotaItemStruct `json:"slot_1"`
-				Slot2 DotaItemStruct `json:"slot_2"`
-				Slot3 DotaItemStruct `json:"slot_3"`
-				Slot4 DotaItemStruct `json:"slot_4"`
-				Slot5 DotaItemStruct `json:"slot_5"`
-				Slot6 DotaItemStruct `json:"slot_6"`
+				Slot1 DotaItem `json:"slot_1"`
+				Slot2 DotaItem `json:"slot_2"`
+				Slot3 DotaItem `json:"slot_3"`
+				Slot4 DotaItem `json:"slot_4"`
+				Slot5 DotaItem `json:"slot_5"`
+				Slot6 DotaItem `json:"slot_6"`
 			} `json:"inventory"`
 			Backpack struct {
-				Slot1 DotaItemStruct `json:"slot_1"`
-				Slot2 DotaItemStruct `json:"slot_2"`
-				Slot3 DotaItemStruct `json:"slot_3"`
+				Slot1 DotaItem `json:"slot_1"`
+				Slot2 DotaItem `json:"slot_2"`
+				Slot3 DotaItem `json:"slot_3"`
 			} `json:"backpack"`
 			Stash struct {
-				Slot1 DotaItemStruct `json:"slot_1"`
-				Slot2 DotaItemStruct `json:"slot_2"`
-				Slot3 DotaItemStruct `json:"slot_3"`
-				Slot4 DotaItemStruct `json:"slot_4"`
-				Slot5 DotaItemStruct `json:"slot_5"`
-				Slot6 DotaItemStruct `json:"slot_6"`
+				Slot1 DotaItem `json:"slot_1"`
+				Slot2 DotaItem `json:"slot_2"`
+				Slot3 DotaItem `json:"slot_3"`
+				Slot4 DotaItem `json:"slot_4"`
+				Slot5 DotaItem `json:"slot_5"`
+				Slot6 DotaItem `json:"slot_6"`
 			} `json:"stash"`
 		} `json:"items"`
 	} `json:"player_stats"`
@@ -177,12 +177,12 @@ type DotaDmg struct {
 type LolMatchSummary struct {
 	MatchLength int64 `json:"match_length"`
 	BlueRoster  struct {
-		Id      int64             `json:"id"`
-		Players []LolPlayerStruct `json:"players"`
+		Id      int64       `json:"id"`
+		Players []LolPlayer `json:"players"`
 	} `json:"blue_roster"`
 	PurpleRoster struct {
-		Id      int64             `json:"id"`
-		Players []LolPlayerStruct `json:"players"`
+		Id      int64       `json:"id"`
+		Players []LolPlayer `json:"players"`
 	} `json:"purple_roster"`
 	Firsts struct {
 		FirstBlood struct {
@@ -223,28 +223,28 @@ type LolMatchSummary struct {
 		Timestamp int64  `json:"timestamp"`
 	} `json:"wards"`
 	KillTimeline []struct {
-		Timestamp int64     `json:"timestamp"`
-		Position  PosStruct `json:"position"`
-		KillerId  int64     `json:"killer_id"`
-		VictimId  int64     `json:"victim_id"`
-		Assists   []int64   `json:"assists"`
+		Timestamp int64   `json:"timestamp"`
+		Position  Pos     `json:"position"`
+		KillerId  int64   `json:"killer_id"`
+		VictimId  int64   `json:"victim_id"`
+		Assists   []int64 `json:"assists"`
 	} `json:"kill_timeline"`
 	ObjectiveEvents struct {
 		Towers []struct {
 			Type    string  `json:"type"`
 			Assists []int64 `json:"assists"`
-			LolLaneEventStruct
+			LolLaneEvent
 		} `json:"towers"`
 		Inihibitors []struct {
-			LolLaneEventStruct
+			LolLaneEvent
 			Assists []int64 `json:"assists"`
 		} `json:"inhibitors"`
-		Barons  []LolEventStruct `json:"barons"`
+		Barons  []LolEvent `json:"barons"`
 		Dragons []struct {
 			Type string `json:"type"`
-			LolEventStruct
+			LolEvent
 		} `json:"dragons"`
-		RiftHeralds []LolEventStruct `json:"rift_heralds"`
+		RiftHeralds []LolEvent `json:"rift_heralds"`
 	} `json:"objective_events"`
 	Draft []struct {
 		RosterId int64 `json:"roster_id"`
@@ -257,7 +257,7 @@ type LolMatchSummary struct {
 	} `json:"draft"`
 }
 
-type LolPlayerStruct struct {
+type LolPlayer struct {
 	PlayerId   int64   `json:"player_id"`
 	Role       string  `json:"role"`
 	Lane       string  `json:"lane"`
@@ -285,22 +285,22 @@ type LolPlayerStruct struct {
 	} `json:"kill_combos"`
 	Items struct {
 		Inventory struct {
-			Slot1 LolItemStruct `json:"slot_1"`
-			Slot2 LolItemStruct `json:"slot_2"`
-			Slot3 LolItemStruct `json:"slot_3"`
-			Slot4 LolItemStruct `json:"slot_4"`
-			Slot5 LolItemStruct `json:"slot_5"`
-			Slot6 LolItemStruct `json:"slot_6"`
-			Slot7 LolItemStruct `json:"slot_7"`
+			Slot1 LolItem `json:"slot_1"`
+			Slot2 LolItem `json:"slot_2"`
+			Slot3 LolItem `json:"slot_3"`
+			Slot4 LolItem `json:"slot_4"`
+			Slot5 LolItem `json:"slot_5"`
+			Slot6 LolItem `json:"slot_6"`
+			Slot7 LolItem `json:"slot_7"`
 		} `json:"inventory"`
 	} `json:"items"`
 	Damage struct {
-		Total        LolDmgStruct `json:"total"`
-		ToHeroes     LolDmgStruct `json:"to_heroes"`
-		DamageTaken  LolDmgStruct `json:"damage_taken"`
-		LargestCrit  int64        `json:"largest_crit"`
-		ToObjectives int64        `json:"to_objectives"`
-		ToTurrets    int64        `json:"to_turrets"`
+		Total        LolDmg `json:"total"`
+		ToHeroes     LolDmg `json:"to_heroes"`
+		DamageTaken  LolDmg `json:"damage_taken"`
+		LargestCrit  int64  `json:"largest_crit"`
+		ToObjectives int64  `json:"to_objectives"`
+		ToTurrets    int64  `json:"to_turrets"`
 	} `json:"damage"`
 	Support struct {
 		AmountHealed     int64 `json:"amount_healed"`
@@ -373,19 +373,19 @@ type LolPlayerStruct struct {
 	} `json:"skillups"`
 }
 
-type LolDmgStruct struct {
+type LolDmg struct {
 	Magic    int64 `json:"magic"`
 	Physical int64 `json:"physical"`
 	True     int64 `json:"true"`
 }
 
-type LolEventStruct struct {
-	Timestamp int64     `json:"timestamp"`
-	Position  PosStruct `json:"position"`
-	KillerId  int64     `json:"killer_id"`
+type LolEvent struct {
+	Timestamp int64 `json:"timestamp"`
+	Position  Pos   `json:"position"`
+	KillerId  int64 `json:"killer_id"`
 }
 
-type LolLaneEventStruct struct {
+type LolLaneEvent struct {
 	Lane string `json:"lane"`
-	LolEventStruct
+	LolEvent
 }

--- a/structs/organisation.go
+++ b/structs/organisation.go
@@ -1,15 +1,15 @@
 package structs
 
-// OrganisationStructPaginated holds a list of TeamStruct as well as information about pages.
-type OrganisationStructPaginated struct {
-	LastPage    int64                `json:"last_page,omitempty"`
-	CurrentPage int64                `json:"current_page,omitempty"`
-	Data        []OrganisationStruct `json:"data,omitempty"`
+// PaginatedOrganisations holds a list of Team as well as information about pages.
+type PaginatedOrganisations struct {
+	LastPage    int64          `json:"last_page,omitempty"`
+	CurrentPage int64          `json:"current_page,omitempty"`
+	Data        []Organisation `json:"data,omitempty"`
 }
 
-// OrganisationStruct represents a logical grouping of Teams across different Games
-type OrganisationStruct struct {
-	Id    int64        `json:"id,omitempty"`
-	Name  string       `json:"name,omitempty"`
-	Teams []TeamStruct `json:"teams"`
+// Organisation represents a logical grouping of Teams across different Games
+type Organisation struct {
+	Id    int64  `json:"id,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Teams []Team `json:"teams"`
 }

--- a/structs/platform.go
+++ b/structs/platform.go
@@ -1,9 +1,9 @@
 package structs
 
-// PlatformStruct represents a third party streaming platform.
-type PlatformStruct struct {
-	Id     int64                `json:"id,omitempty"`
-	Name   string               `json:"name,omitempty"`
-	Color  string               `json:"color,omitempty"`
-	Images PlatformImagesStruct `json:"images,omitempty"`
+// Platform represents a third party streaming platform.
+type Platform struct {
+	Id     int64          `json:"id,omitempty"`
+	Name   string         `json:"name,omitempty"`
+	Color  string         `json:"color,omitempty"`
+	Images PlatformImages `json:"images,omitempty"`
 }

--- a/structs/player.go
+++ b/structs/player.go
@@ -1,26 +1,26 @@
 package structs
 
-// PlayerStructPaginated holds a list of PlayerStruct as well as information about pages.
-type PlayerStructPaginated struct {
-	LastPage    int64          `json:"last_page,omitempty"`
-	CurrentPage int64          `json:"current_page,omitempty"`
-	Data        []PlayerStruct `json:"data,omitempty"`
+// PaginatedPlayers holds a list of Player as well as information about pages.
+type PaginatedPlayers struct {
+	LastPage    int64    `json:"last_page,omitempty"`
+	CurrentPage int64    `json:"current_page,omitempty"`
+	Data        []Player `json:"data,omitempty"`
 }
 
-// PlayerStruct represents a player that competes in Series' and Matches.
-type PlayerStruct struct {
-	Id                  int64                      `json:"id,omitempty"`
-	FirstName           string                     `json:"first_name"`
-	LastName            string                     `json:"last_name"`
-	Nickname            string                     `json:"nick_name,omitempty"`
-	DeletedAt           *string                    `json:"deleted_at"`
-	Images              PlayerImagesStruct         `json:"images,omitempty"`
-	Country             *CountryStruct             `json:"country,omitempty"`
-	Roles               []RoleStruct               `json:"roles"`
-	Race                *RaceStruct                `json:"race,omitempty"`
-	Team                *TeamStruct                `json:"team,omitempty"`
-	PlayerStats         PlayerStatsStruct          `json:"player_stats,omitempty"`
-	Rosters             []DefaultRosterStruct      `json:"rosters,omitempty"`
-	Game                GameStruct                 `json:"game,omitempty"`
-	SocialMediaAccounts []SocialMediaAccountStruct `json:"social_media_accounts,omitempty"`
+// Player represents a player that competes in Series' and Matches.
+type Player struct {
+	Id                  int64                `json:"id,omitempty"`
+	FirstName           string               `json:"first_name"`
+	LastName            string               `json:"last_name"`
+	Nickname            string               `json:"nick_name,omitempty"`
+	DeletedAt           *string              `json:"deleted_at"`
+	Images              PlayerImages         `json:"images,omitempty"`
+	Country             *Country             `json:"country,omitempty"`
+	Roles               []Role               `json:"roles"`
+	Race                *Race                `json:"race,omitempty"`
+	Team                *Team                `json:"team,omitempty"`
+	PlayerStats         PlayerStats          `json:"player_stats,omitempty"`
+	Rosters             []DefaultRoster      `json:"rosters,omitempty"`
+	Game                Game                 `json:"game,omitempty"`
+	SocialMediaAccounts []SocialMediaAccount `json:"social_media_accounts,omitempty"`
 }

--- a/structs/player_stats.go
+++ b/structs/player_stats.go
@@ -4,65 +4,65 @@ import (
 	"encoding/json"
 )
 
-// PlayerStatsStruct hold performance statistics about a particular Player.
-type PlayerStatsStruct struct {
-	SinglePlayer *SinglePlayerStatsStruct    `json:"single_player,omitempty"` // Null when player does not play single player game. Otherwise format is equal to stats for a team
-	PlayByPlay   PlayerPlayByPlayStatsStruct `json:"play_by_play"`
+// PlayerStats hold performance statistics about a particular Player.
+type PlayerStats struct {
+	SinglePlayer *SinglePlayerStats    `json:"single_player,omitempty"` // Null when player does not play single player game. Otherwise format is equal to stats for a team
+	PlayByPlay   PlayerPlayByPlayStats `json:"play_by_play"`
 }
 
-// SinglePlayerStatsStruct hold information for players playing single-player games.
+// SinglePlayerStats hold information for players playing single-player games.
 // For team games see the players corresponding Team and TeamStats.
-type SinglePlayerStatsStruct struct {
+type SinglePlayerStats struct {
 	Streak struct {
 		Series struct {
-			StreakScopeStruct // defined in stats.go
+			StreakScope // defined in stats.go
 		} `json:"series,omitempty"`
 		Match struct {
-			StreakScopeStruct // defined in stats.go
+			StreakScope // defined in stats.go
 		} `json:"match,omitempty"`
 	} `json:"streak,omitempty"`
 	Winrate struct {
 		Series struct {
-			WinrateSeriesScopeStruct // defined in stats.go
+			WinrateSeriesScope // defined in stats.go
 		} `json:"series,omitempty"`
 		Match struct {
-			WinrateMatchScopeStruct // defined in stats.go
+			WinrateMatchScope // defined in stats.go
 		} `json:"match,omitempty"`
 	} `json:"winrate,omitempty"`
 	Nemesis *struct {
 		Series struct {
-			Competitor PlayerStruct `json:"competitor,omitempty"` // defined in stats.go
-			Losses     int64        `json:"losses"`
+			Competitor Player `json:"competitor,omitempty"` // defined in stats.go
+			Losses     int64  `json:"losses"`
 		} `json:"series,omitempty"`
 		Match struct {
-			Competitor PlayerStruct `json:"competitor,omitempty"` // defined in stats.go
-			Losses     int64        `json:"losses"`
+			Competitor Player `json:"competitor,omitempty"` // defined in stats.go
+			Losses     int64  `json:"losses"`
 		} `json:"match,omitempty"`
 	} `json:"nemesis,omitempty"`
 	Dominating *struct {
 		Series struct {
-			Competitor PlayerStruct `json:"competitor,omitempty"` // defined in stats.go
-			Wins       int64        `json:"wins"`
+			Competitor Player `json:"competitor,omitempty"` // defined in stats.go
+			Wins       int64  `json:"wins"`
 		} `json:"series,omitempty"`
 		Match struct {
-			Competitor PlayerStruct `json:"competitor,omitempty"` // defined in stats.go
-			Wins       int64        `json:"wins"`
+			Competitor Player `json:"competitor,omitempty"` // defined in stats.go
+			Wins       int64  `json:"wins"`
 		} `json:"match,omitempty"`
 	} `json:"dominating,omitempty"`
 }
 
-// PlayByPlayStatsStruct holds information about play by play statistics for a certain player.
-type PlayerPlayByPlayStatsStruct interface{}
+// PlayByPlayStats holds information about play by play statistics for a certain player.
+type PlayerPlayByPlayStats interface{}
 
-type playerPlayByPlayStatsStruct PlayerPlayByPlayStatsStruct
+type playerPlayByPlayStats PlayerPlayByPlayStats
 
-func (p *PlayerStatsStruct) UnmarshalJSON(data []byte) error {
+func (p *PlayerStats) UnmarshalJSON(data []byte) error {
 	var partial map[string]json.RawMessage
 	if err := json.Unmarshal(data, &partial); err != nil {
 		return err
 	}
 
-	var single_player SinglePlayerStatsStruct
+	var single_player SinglePlayerStats
 	if err := json.Unmarshal(partial["single_player"], &single_player); err != nil {
 		return err
 	}
@@ -100,30 +100,30 @@ func (p *PlayerStatsStruct) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// CsPlayerByPlayStatsStruct holds play by play stats for cs players
+// CsPlayerByPlayStats holds play by play stats for cs players
 type CsPlayerStats struct {
 	Overall struct {
-		CsPlayerPerformanceStruct
+		CsPlayerPerformance
 		Plants  float64 `json:"plants"`
 		Defuses float64 `json:"defuses"`
 	} `json:"over_all"`
 	PerMap []struct {
-		Map    MapStruct `json:"map"`
+		Map    Map `json:"map"`
 		CtSide struct {
-			CsPlayerPerformanceStruct
+			CsPlayerPerformance
 			Defuses float64 `json:"defuses"`
 		} `json:"ct_side"`
 		TSide struct {
-			CsPlayerPerformanceStruct
+			CsPlayerPerformance
 			Plants float64 `json:"plants"`
 		} `json:"t_side"`
 		Overall struct {
-			CsPlayerPerformanceStruct
+			CsPlayerPerformance
 		} `json:"over_all"`
 	} `json:"per_map"`
 	PerWeapon []struct {
-		Weapon        WeaponStruct `json:"weapon"`
-		DmgGivenRound int64        `json:"dmg_given_round"`
+		Weapon        Weapon `json:"weapon"`
+		DmgGivenRound int64  `json:"dmg_given_round"`
 		Accuracy      struct {
 			General  float64 `json:"general"`
 			Headshot float64 `json:"head_shot"`
@@ -132,9 +132,9 @@ type CsPlayerStats struct {
 	} `json:"per_weapon"`
 }
 
-// CsPlayerPerformanceStruct holds some general data about a players performance. This
+// CsPlayerPerformance holds some general data about a players performance. This
 // struct is re-used for different levels data (e.g per_map and over_all).
-type CsPlayerPerformanceStruct struct {
+type CsPlayerPerformance struct {
 	Kills       float64 `json:"kills"`
 	Assists     float64 `json:"assists"`
 	Deaths      float64 `json:"deaths"`
@@ -147,18 +147,18 @@ type CsPlayerPerformanceStruct struct {
 	} `json:"accuracy"`
 }
 
-// DotaPlayerByPlayStatsStruct holds play by play stats for dota players
+// DotaPlayerByPlayStats holds play by play stats for dota players
 type DotaPlayerStats struct {
-	Stats     DotaPlayerPerformanceStruct `json:"stats"`
+	Stats     DotaPlayerPerformance `json:"stats"`
 	HeroStats struct {
 		Attribute struct {
-			Strength     DotaPlayerPerformanceStruct `json:"strength"`
-			Agility      DotaPlayerPerformanceStruct `json:"agility"`
-			Intelligence DotaPlayerPerformanceStruct `json:"intelligence"`
+			Strength     DotaPlayerPerformance `json:"strength"`
+			Agility      DotaPlayerPerformance `json:"agility"`
+			Intelligence DotaPlayerPerformance `json:"intelligence"`
 		} `json:"attribute"`
 		TopHeroes []struct {
-			Hero HeroStruct `json:"hero"`
-			DotaPlayerPerformanceStruct
+			Hero Hero `json:"hero"`
+			DotaPlayerPerformance
 		} `json:"top_heroes"`
 	} `json:"hero_stats"`
 	FactionStats struct {
@@ -173,9 +173,9 @@ type DotaPlayerStats struct {
 	} `json:"faction_stats"`
 }
 
-// DotaPlayerPerformanceStruct holds some data about a a players performance. This
+// DotaPlayerPerformance holds some data about a a players performance. This
 // struct is re-used for different levels of data (e.g hero_stats and top_hero)
-type DotaPlayerPerformanceStruct struct {
+type DotaPlayerPerformance struct {
 	Matches        int64   `json:"matches"`
 	Wins           int64   `json:"wins"`
 	AvgKills       float64 `json:"avg_kills"`

--- a/structs/race.go
+++ b/structs/race.go
@@ -1,9 +1,9 @@
 package structs
 
-// RaceStruct represents a race, faction, class etc. in a Game.
-type RaceStruct struct {
-	Id     int64            `json:"id,omitempty"`
-	GameId int64            `json:"game_id,omitempty"`
-	Name   string           `json:"name,omitempty"`
-	Images RaceImagesStruct `json:"images,omitempty"`
+// Race represents a race, faction, class etc. in a Game.
+type Race struct {
+	Id     int64      `json:"id,omitempty"`
+	GameId int64      `json:"game_id,omitempty"`
+	Name   string     `json:"name,omitempty"`
+	Images RaceImages `json:"images,omitempty"`
 }

--- a/structs/role.go
+++ b/structs/role.go
@@ -1,6 +1,6 @@
 package structs
 
-type RoleStruct struct {
+type Role struct {
 	Name string  `json:"name"`
 	From string  `json:"from"`
 	To   *string `json:"to"`

--- a/structs/roster.go
+++ b/structs/roster.go
@@ -1,10 +1,10 @@
 package structs
 
-// RosterStruct represents a roster (or line-up) in a team game.
-type RosterStruct struct {
-	Id          int64              `json:"id,omitempty"`
-	Teams       []TeamStruct       `json:"teams,omitempty"`
-	Players     []PlayerStruct     `json:"players,omitempty"`
-	RosterStats *RosterStatsStruct `json:"roster_stats"`
-	Game        GameStruct         `json:"game"`
+// Roster represents a roster (or line-up) in a team game.
+type Roster struct {
+	Id          int64        `json:"id,omitempty"`
+	Teams       []Team       `json:"teams,omitempty"`
+	Players     []Player     `json:"players,omitempty"`
+	RosterStats *RosterStats `json:"roster_stats"`
+	Game        Game         `json:"game"`
 }

--- a/structs/roster_stats.go
+++ b/structs/roster_stats.go
@@ -1,27 +1,27 @@
 package structs
 
-// RosterStatsStruct hold performance information about a particular Roster.
-type RosterStatsStruct struct {
+// RosterStats hold performance information about a particular Roster.
+type RosterStats struct {
 	Streak struct {
 		Match struct {
-			StreakScopeStruct // defined in stats.go
+			StreakScope // defined in stats.go
 		} `json:"match,omitempty"`
 	} `json:"streak,omitempty"`
 	Winrate struct {
 		Match struct {
-			WinrateMatchScopeStruct // defined in stats.go
+			WinrateMatchScope // defined in stats.go
 		} `json:"match,omitempty"`
 	} `json:"winrate,omitempty"`
 	Nemesis *struct {
 		Match struct {
-			Roster RosterStruct `json:"roster"`
-			Losses int64        `json:"losses"`
+			Roster Roster `json:"roster"`
+			Losses int64  `json:"losses"`
 		} `json:"match,omitempty"`
 	} `json:"nemesis"`
 	Dominating *struct {
 		Match struct {
-			Roster RosterStruct `json:"roster"`
-			Wins   int64        `json:"wins"`
+			Roster Roster `json:"roster"`
+			Wins   int64  `json:"wins"`
 		} `json:"match,omitempty"`
 	} `json:"dominating"`
 }

--- a/structs/scores.go
+++ b/structs/scores.go
@@ -1,0 +1,4 @@
+package structs
+
+// Scores holds informaton about the scores of a particular Match or Series.
+type Scores map[string]int64

--- a/structs/scores_struct.go
+++ b/structs/scores_struct.go
@@ -1,4 +1,0 @@
-package structs
-
-// ScoresStruct holds informaton about the scores of a particular Match or Series.
-type ScoresStruct map[string]int64

--- a/structs/searchresult.go
+++ b/structs/searchresult.go
@@ -1,7 +1,7 @@
 package structs
 
-// SearchResultStruct represents a result from the /search endpoint.
-type SearchResultStruct struct {
+// SearchResult represents a result from the /search endpoint.
+type SearchResult struct {
 	Id       int64   `json:"id,omitempty"`
 	Matched  string  `json:"matched,omitempty"`
 	AltLabel string  `json:"alt_label,omitempty"`

--- a/structs/seeding.go
+++ b/structs/seeding.go
@@ -1,4 +1,4 @@
 package structs
 
-// SeedingStruct represents the seeding of all competitors in the related Series.
-type SeedingStruct map[string]int64
+// Seeding represents the seeding of all competitors in the related Series.
+type Seeding map[string]int64

--- a/structs/series.go
+++ b/structs/series.go
@@ -33,8 +33,12 @@ type SeriesStruct struct {
 	Tournament      TournamentStruct        `json:"tournament,omitempty"`
 	Performance     SeriesPerformanceStruct `json:"performance,omitempty"`
 	SportsbookOdds  []SportsbookOddsStruct  `json:"sportsbook_odds"`
-	Chain           *[]int64                `json:"chain"`
-	Summary         SeriesSummary           `json:"summary"`
+	Chain           *[]struct {
+		RootId   int64 `json:"root_id"`
+		SeriesId int64 `json:"series_id"`
+		Order    int64 `json:"order"`
+	} `json:"chain"`
+	Summary SeriesSummary `json:"summary"`
 }
 
 // avoid recursion when unmarshaling

--- a/structs/series.go
+++ b/structs/series.go
@@ -2,37 +2,37 @@ package structs
 
 import "encoding/json"
 
-// SeriesStructPaginated holds a list of SeriesStruct as well as information about pages.
-type SeriesStructPaginated struct {
-	LastPage    int64          `json:"last_page,omitempty"`
-	CurrentPage int64          `json:"current_page,omitempty"`
-	Data        []SeriesStruct `json:"data,omitempty"`
+// PaginatedSeries holds a list of Series as well as information about pages.
+type PaginatedSeries struct {
+	LastPage    int64    `json:"last_page,omitempty"`
+	CurrentPage int64    `json:"current_page,omitempty"`
+	Data        []Series `json:"data,omitempty"`
 }
 
-// SeriesStruct represents a Series of Matches.
-type SeriesStruct struct {
-	Id              int64                   `json:"id,omitempty"`
-	Title           string                  `json:"title,omitempty"`
-	BestOf          int64                   `json:"bestOf,omitempty"`
-	Tier            *int64                  `json:"tier"`
-	Start           *string                 `json:"start"`
-	End             *string                 `json:"end"`
-	PostponedFrom   *string                 `json:"postponed_from"`
-	DeletedAt       *string                 `json:"deleted_at"`
-	Scores          *ScoresStruct           `json:"scores"`
-	Forfeit         ForfeitStruct           `json:"forfeit,omitempty"`
-	Streamed        bool                    `json:"streamed"`
-	Seeding         SeedingStruct           `json:"seeding,omitempty"`
-	Rosters         []RosterStruct          `json:"rosters,omitempty"`
-	Game            GameStruct              `json:"game,omitempty"`
-	Matches         []MatchStruct           `json:"matches,omitempty"`
-	Casters         []CasterStruct          `json:"casters,omitempty"`
-	TournamentId    int64                   `json:"tournament_id,omitempty"`
-	SubstageId      int64                   `json:"substage_id,omitempty"`
-	BracketPosition *BracketPositionStruct  `json:"bracket_pos"`
-	Tournament      TournamentStruct        `json:"tournament,omitempty"`
-	Performance     SeriesPerformanceStruct `json:"performance,omitempty"`
-	SportsbookOdds  []SportsbookOddsStruct  `json:"sportsbook_odds"`
+// Series represents a Series of Matches.
+type Series struct {
+	Id              int64             `json:"id,omitempty"`
+	Title           string            `json:"title,omitempty"`
+	BestOf          int64             `json:"bestOf,omitempty"`
+	Tier            *int64            `json:"tier"`
+	Start           *string           `json:"start"`
+	End             *string           `json:"end"`
+	PostponedFrom   *string           `json:"postponed_from"`
+	DeletedAt       *string           `json:"deleted_at"`
+	Scores          *Scores           `json:"scores"`
+	Forfeit         Forfeit           `json:"forfeit,omitempty"`
+	Streamed        bool              `json:"streamed"`
+	Seeding         Seeding           `json:"seeding,omitempty"`
+	Rosters         []Roster          `json:"rosters,omitempty"`
+	Game            Game              `json:"game,omitempty"`
+	Matches         []Match           `json:"matches,omitempty"`
+	Casters         []Caster          `json:"casters,omitempty"`
+	TournamentId    int64             `json:"tournament_id,omitempty"`
+	SubstageId      int64             `json:"substage_id,omitempty"`
+	BracketPosition *BracketPosition  `json:"bracket_pos"`
+	Tournament      Tournament        `json:"tournament,omitempty"`
+	Performance     SeriesPerformance `json:"performance,omitempty"`
+	SportsbookOdds  []SportsbookOdds  `json:"sportsbook_odds"`
 	Chain           *[]struct {
 		RootId   int64 `json:"root_id"`
 		SeriesId int64 `json:"series_id"`
@@ -42,10 +42,10 @@ type SeriesStruct struct {
 }
 
 // avoid recursion when unmarshaling
-type seriesStruct SeriesStruct
+type series Series
 
 // We need to unmarshal summary into the game-specific struct
-func (s *SeriesStruct) UnmarshalJSON(data []byte) error {
+func (s *Series) UnmarshalJSON(data []byte) error {
 	// find the outer-most keys
 	var partial map[string]json.RawMessage
 	if err := json.Unmarshal(data, &partial); err != nil {
@@ -57,7 +57,7 @@ func (s *SeriesStruct) UnmarshalJSON(data []byte) error {
 	delete(partial, "summary")
 	data, _ = json.Marshal(partial)
 
-	var ss seriesStruct
+	var ss series
 	if err := json.Unmarshal(data, &ss); err != nil {
 		return err
 	}
@@ -90,7 +90,7 @@ func (s *SeriesStruct) UnmarshalJSON(data []byte) error {
 		}
 	}
 
-	*s = SeriesStruct(ss)
+	*s = Series(ss)
 	return nil
 
 }

--- a/structs/series_incident.go
+++ b/structs/series_incident.go
@@ -1,8 +1,8 @@
 package structs
 
-// SeriesIncidentStruct holds information about all incidents associated with a
+// SeriesIncidents holds information about all incidents associated with a
 // Series and all it's Matches.
-type SeriesIncidentsStruct struct {
-	SeriesIncidents []IncidentStruct `json:"series_incidents"`
-	MatchIncidents  []IncidentStruct `json:"match_incidents"`
+type SeriesIncidents struct {
+	SeriesIncidents []Incident `json:"series_incidents"`
+	MatchIncidents  []Incident `json:"match_incidents"`
 }

--- a/structs/series_performance.go
+++ b/structs/series_performance.go
@@ -1,8 +1,8 @@
 package structs
 
-// SeriesPerformanceStruct is associated with a Series and contains performance information
+// SeriesPerformance is associated with a Series and contains performance information
 // about the Teams or Players participating in the Series.
-type SeriesPerformanceStruct struct {
-	PastEncounters    []SeriesStruct            `json:"past_encounters,omitempty"`
-	RecentPerformance map[string][]SeriesStruct `json:"recent_performance,omitempty"`
+type SeriesPerformance struct {
+	PastEncounters    []Series            `json:"past_encounters,omitempty"`
+	RecentPerformance map[string][]Series `json:"recent_performance,omitempty"`
 }

--- a/structs/social_media_account.go
+++ b/structs/social_media_account.go
@@ -1,7 +1,7 @@
 package structs
 
-// SocialMediaAccountStruct represents a social media account for a Player or Team
-type SocialMediaAccountStruct struct {
+// SocialMediaAccount represents a social media account for a Player or Team
+type SocialMediaAccount struct {
 	Name string `json:"name,omitemtpy"`
 	Slug string `json:"slug,omitempty"`
 	Url  string `json:"url,omitmepty"`

--- a/structs/sportsbook.go
+++ b/structs/sportsbook.go
@@ -1,14 +1,14 @@
 package structs
 
-// SportsbookOddsStruct is a top-level struct holding information about sportsbook odds.
-type SportsbookOddsStruct struct {
-	Sportsbook string          `json:"sportsbook"`
-	Link       string          `json:"link"`
-	Moneyline  MoneylineStruct `json:"moneyline"`
+// SportsbookOdds is a top-level struct holding information about sportsbook odds.
+type SportsbookOdds struct {
+	Sportsbook string    `json:"sportsbook"`
+	Link       string    `json:"link"`
+	Moneyline  Moneyline `json:"moneyline"`
 }
 
-// MoneylineStruct holds information about the mouneyline for a particular sportsbook.
-type MoneylineStruct struct {
+// Moneyline holds information about the mouneyline for a particular sportsbook.
+type Moneyline struct {
 	Home        float64  `json:"home"`
 	HomeBetSlip *string  `json:"home_bet_slip"`
 	Away        float64  `json:"away"`

--- a/structs/stage.go
+++ b/structs/stage.go
@@ -1,9 +1,9 @@
 package structs
 
-// StageStruct represents a phase in a Tournament and a higher level grouping of Substages.
-type StageStruct struct {
-	Id        int64            `json:"id,omitempty"`
-	Title     string           `json:"title,omitempty"`
-	DeletedAt *string          `json:"deleted_at"`
-	Substages []SubstageStruct `json:"substages"`
+// Stage represents a phase in a Tournament and a higher level grouping of Substages.
+type Stage struct {
+	Id        int64      `json:"id,omitempty"`
+	Title     string     `json:"title,omitempty"`
+	DeletedAt *string    `json:"deleted_at"`
+	Substages []Substage `json:"substages"`
 }

--- a/structs/stats.go
+++ b/structs/stats.go
@@ -1,35 +1,35 @@
 package structs
 
-// StreakScopeStruct is the second-level object holding streak statistics.
-type StreakScopeStruct struct {
+// StreakScope is the second-level object holding streak statistics.
+type StreakScope struct {
 	Current int64 `json:"current"`
 	Best    int64 `json:"best"`
 	Worst   int64 `json:"worst"`
 }
 
-// WinrateScopeStruct is a second-level object holding winrate statistics for matches.
-type WinrateMatchScopeStruct struct {
-	Rate    float64               `json:"rate"`
-	History int64                 `json:"history"`
-	PerMap  []WinratePerMapStruct `json:"per_map"`
+// WinrateScope is a second-level object holding winrate statistics for matches.
+type WinrateMatchScope struct {
+	Rate    float64         `json:"rate"`
+	History int64           `json:"history"`
+	PerMap  []WinratePerMap `json:"per_map"`
 }
 
-// WinratePerMapStruct holds the innermost JSON about winrates related to a single map.
-type WinratePerMapStruct struct {
-	Map     MapStruct `json:"map,omitempty"`
-	Rate    float64   `json:"rate"`
-	History int64     `json:"history"`
+// WinratePerMap holds the innermost JSON about winrates related to a single map.
+type WinratePerMap struct {
+	Map     Map     `json:"map,omitempty"`
+	Rate    float64 `json:"rate"`
+	History int64   `json:"history"`
 }
 
-// WinrateScopeStruct is a second-level object holding winrate statistics for series'.
-type WinrateSeriesScopeStruct struct {
-	Rate      float64                  `json:"rate"`
-	History   int64                    `json:"history"`
-	PerFormat []WinratePerFormatStruct `json:"per_format"`
+// WinrateScope is a second-level object holding winrate statistics for series'.
+type WinrateSeriesScope struct {
+	Rate      float64            `json:"rate"`
+	History   int64              `json:"history"`
+	PerFormat []WinratePerFormat `json:"per_format"`
 }
 
-// WinratePerFormatStruct holds the innermost JSON about winrates related to a specific format.
-type WinratePerFormatStruct struct {
+// WinratePerFormat holds the innermost JSON about winrates related to a specific format.
+type WinratePerFormat struct {
 	BestOf  int64   `json:"best_of"`
 	Rate    float64 `json:"rate"`
 	History int64   `json:"history"`

--- a/structs/stream.go
+++ b/structs/stream.go
@@ -1,15 +1,15 @@
 package structs
 
-// StreamStruct represents a broadcast on a third party platform.
-type StreamStruct struct {
-	Id          int64              `json:"id,omitempty"`
-	Username    string             `json:"username,omitempty"`
-	DisplayName string             `json:"display_name,omitempty"`
-	StatusText  string             `json:"status_text,omitempty"`
-	ViewerCount int64              `json:"viewer_count"`
-	Online      int64              `json:"online"`
-	LastOnline  string             `json:"last_online,omitempty"`
-	Images      StreamImagesStruct `json:"images,omitempty"`
-	Url         string             `json:"url,omitempty"`
-	Platform    PlatformStruct     `json:"platform,omitempty"`
+// Stream represents a broadcast on a third party platform.
+type Stream struct {
+	Id          int64        `json:"id,omitempty"`
+	Username    string       `json:"username,omitempty"`
+	DisplayName string       `json:"display_name,omitempty"`
+	StatusText  string       `json:"status_text,omitempty"`
+	ViewerCount int64        `json:"viewer_count"`
+	Online      int64        `json:"online"`
+	LastOnline  string       `json:"last_online,omitempty"`
+	Images      StreamImages `json:"images,omitempty"`
+	Url         string       `json:"url,omitempty"`
+	Platform    Platform     `json:"platform,omitempty"`
 }

--- a/structs/substage.go
+++ b/structs/substage.go
@@ -1,23 +1,23 @@
 package structs
 
-// SubstageStruct is the lowest structure of a Tournament and is a grouping of Series.
-type SubstageStruct struct {
-	TournamentId int64               `json:"tournament_id,omitempty"`
-	StageId      int64               `json:"stage_id,omitempty"`
-	Id           int64               `json:"id,omitempty"`
-	Title        string              `json:"title,omitempty"`
-	Tier         int64               `json:"tier"`
-	Type         int64               `json:"type"`
-	Order        int64               `json:"order"`
-	Rules        SubstageRulesStruct `json:"rules"`
-	Standing     []StandingsStruct   `json:"standings"`
-	Series       []SeriesStruct      `json:"series,omitempty"`
-	Rosters      []RosterStruct      `json:"rosters,omitempty"`
-	DeletedAt    *string             `json:"deleted_at"`
+// Substage is the lowest structure of a Tournament and is a grouping of Series.
+type Substage struct {
+	TournamentId int64         `json:"tournament_id,omitempty"`
+	StageId      int64         `json:"stage_id,omitempty"`
+	Id           int64         `json:"id,omitempty"`
+	Title        string        `json:"title,omitempty"`
+	Tier         int64         `json:"tier"`
+	Type         int64         `json:"type"`
+	Order        int64         `json:"order"`
+	Rules        SubstageRules `json:"rules"`
+	Standing     []Standings   `json:"standings"`
+	Series       []Series      `json:"series,omitempty"`
+	Rosters      []Roster      `json:"rosters,omitempty"`
+	DeletedAt    *string       `json:"deleted_at"`
 }
 
-// SubstageRulesStruct hold information about the rules for a particular substage.
-type SubstageRulesStruct struct {
+// SubstageRules hold information about the rules for a particular substage.
+type SubstageRules struct {
 	Advance struct {
 		Number     *int64 `json:"number"`
 		SubstageId *int64 `json:"substage_id"`
@@ -34,8 +34,8 @@ type SubstageRulesStruct struct {
 	}
 }
 
-// StandsStruct represents the current standings in a substage.
-type StandingsStruct struct {
+// Stands represents the current standings in a substage.
+type Standings struct {
 	RosterId int64  `json:"roster_id"`
 	Points   *int64 `json:"points"`
 	Wins     int64  `json:"wins"`

--- a/structs/team.go
+++ b/structs/team.go
@@ -1,25 +1,25 @@
 package structs
 
-// TeamStructPaginated holds a list of TeamStruct as well as information about pages.
-type TeamStructPaginated struct {
-	LastPage    int64        `json:"last_page,omitempty"`
-	CurrentPage int64        `json:"current_page,omitempty"`
-	Data        []TeamStruct `json:"data,omitempty"`
+// PaginatedTeams holds a list of Team as well as information about pages.
+type PaginatedTeams struct {
+	LastPage    int64  `json:"last_page,omitempty"`
+	CurrentPage int64  `json:"current_page,omitempty"`
+	Data        []Team `json:"data,omitempty"`
 }
 
-// TeamStruct represents a team that competes in Series' and Matches.
-type TeamStruct struct {
-	Id                  int64                      `json:"id,omitempty"`
-	Name                string                     `json:"name,omitempty"`
-	ShortName           string                     `json:"short_name,omitempty"`
-	DeletedAt           *string                    `json:"deleted_at"`
-	Images              TeamImagesStruct           `json:"images,omitempty"`
-	Country             *CountryStruct             `json:"country"`
-	TeamStats           TeamStatsStruct            `json:"team_stats,omitempty"`
-	Players             *[]PlayerStruct            `json:"players,omitempty"`
-	Rosters             []DefaultRosterStruct      `json:"rosters,omitempty"`
-	UpcomingSeries      []SeriesStruct             `json:"upcoming_series"`
-	RecentSeries        []SeriesStruct             `json:"recent_series"`
-	Game                GameStruct                 `json:"game,omitempty"`
-	SocialMediaAccounts []SocialMediaAccountStruct `json:"social_media_accounts,omitempty"`
+// Team represents a team that competes in Series' and Matches.
+type Team struct {
+	Id                  int64                `json:"id,omitempty"`
+	Name                string               `json:"name,omitempty"`
+	ShortName           string               `json:"short_name,omitempty"`
+	DeletedAt           *string              `json:"deleted_at"`
+	Images              TeamImages           `json:"images,omitempty"`
+	Country             *Country             `json:"country"`
+	TeamStats           TeamStats            `json:"team_stats,omitempty"`
+	Players             *[]Player            `json:"players,omitempty"`
+	Rosters             []DefaultRoster      `json:"rosters,omitempty"`
+	UpcomingSeries      []Series             `json:"upcoming_series"`
+	RecentSeries        []Series             `json:"recent_series"`
+	Game                Game                 `json:"game,omitempty"`
+	SocialMediaAccounts []SocialMediaAccount `json:"social_media_accounts,omitempty"`
 }

--- a/structs/team_stats.go
+++ b/structs/team_stats.go
@@ -4,42 +4,42 @@ import (
 	"encoding/json"
 )
 
-// TeamStatsStruct holds performance statistics about a particular Team.
-type TeamStatsStruct struct {
+// TeamStats holds performance statistics about a particular Team.
+type TeamStats struct {
 	Streak struct {
 		Series struct {
-			StreakScopeStruct // defined in stats.go
+			StreakScope // defined in stats.go
 		} `json:"series,omitempty"`
 		Match struct {
-			StreakScopeStruct // defined in stats.go
+			StreakScope // defined in stats.go
 		} `json:"match,omitempty"`
 	} `json:"streak,omitempty"`
 	Winrate struct {
 		Series struct {
-			WinrateSeriesScopeStruct // defined in stats.go
+			WinrateSeriesScope // defined in stats.go
 		} `json:"series,omitempty"`
 		Match struct {
-			WinrateMatchScopeStruct // defined in stats.go
+			WinrateMatchScope // defined in stats.go
 		} `json:"match,omitempty"`
 	} `json:"winrate,omitempty"`
 	Nemesis *struct {
 		Series struct {
-			Competitor TeamStruct `json:"competitor,omitempty"` // defined in stats.go
-			Losses     int64      `json:"losses"`
+			Competitor Team  `json:"competitor,omitempty"` // defined in stats.go
+			Losses     int64 `json:"losses"`
 		} `json:"series,omitempty"`
 		Match struct {
-			Competitor TeamStruct `json:"competitor,omitempty"` // defined in stats.go
-			Losses     int64      `json:"losses"`
+			Competitor Team  `json:"competitor,omitempty"` // defined in stats.go
+			Losses     int64 `json:"losses"`
 		} `json:"match,omitempty"`
 	} `json:"nemesis,omitempty"`
 	Dominating *struct {
 		Series struct {
-			Competitor TeamStruct `json:"competitor,omitempty"` // defined in stats.go
-			Wins       int64      `json:"wins"`
+			Competitor Team  `json:"competitor,omitempty"` // defined in stats.go
+			Wins       int64 `json:"wins"`
 		} `json:"series,omitempty"`
 		Match struct {
-			Competitor TeamStruct `json:"competitor,omitempty"` // defined in stats.go
-			Wins       int64      `json:"wins"`
+			Competitor Team  `json:"competitor,omitempty"` // defined in stats.go
+			Wins       int64 `json:"wins"`
 		} `json:"match,omitempty"`
 	} `json:"dominating,omitempty"`
 	PlayByPlay TeamPlayByPlayStats `json:"play_by_play"`
@@ -47,9 +47,9 @@ type TeamStatsStruct struct {
 
 type TeamPlayByPlayStats interface{}
 
-type teamStatsStruct TeamStatsStruct
+type teamStats TeamStats
 
-func (t *TeamStatsStruct) UnmarshalJSON(data []byte) error {
+func (t *TeamStats) UnmarshalJSON(data []byte) error {
 	var partial map[string]json.RawMessage
 	if err := json.Unmarshal(data, &partial); err != nil {
 		return err
@@ -61,7 +61,7 @@ func (t *TeamStatsStruct) UnmarshalJSON(data []byte) error {
 	data, _ = json.Marshal(partial)
 
 	// Unmarshal every but the "play_by_play" key
-	var tt teamStatsStruct
+	var tt teamStats
 	if err := json.Unmarshal(data, &tt); err != nil {
 		return err
 	}
@@ -99,7 +99,7 @@ func (t *TeamStatsStruct) UnmarshalJSON(data []byte) error {
 		}
 		tt.PlayByPlay = tmp
 	}
-	*t = TeamStatsStruct(tt)
+	*t = TeamStats(tt)
 
 	return nil
 }
@@ -109,57 +109,57 @@ type CsTeamStats struct {
 	Totals struct {
 		Kills  int64 `json:"kills"`
 		Deaths int64 `json:"deaths"`
-		CsTeamCommonStatsStruct
+		CsTeamCommonStats
 	} `json:"totals"`
 	Maps []struct {
-		Map MapStruct `json:"map"`
-		CsTeamCommonStatsStruct
+		Map Map `json:"map"`
+		CsTeamCommonStats
 	} `json:"maps"`
 	Marksman []struct {
-		PlayerId int64        `json:"player_id"`
-		Adr      float64      `json:"adr"`
-		Weapon   WeaponStruct `json:"weapon"`
+		PlayerId int64   `json:"player_id"`
+		Adr      float64 `json:"adr"`
+		Weapon   Weapon  `json:"weapon"`
 	} `json:"marksman"`
 	TopStats struct {
 		Kills struct {
-			PlayerAgainstStruct
+			PlayerAgainst
 			Kills int64 `json:"kills"`
 		} `json:"kills"`
 		Adr struct {
-			PlayerAgainstStruct
+			PlayerAgainst
 			Adr float64 `json:"adr"`
 		} `json:"adr"`
 		Assists struct {
-			PlayerAgainstStruct
+			PlayerAgainst
 			Assists int64 `json:"assists"`
 		} `json:"assists"`
 		Plants struct {
-			PlayerAgainstStruct
+			PlayerAgainst
 			Plants int64 `json:"plants"`
 		} `json:"plants"`
 		Defuses struct {
-			PlayerAgainstStruct
+			PlayerAgainst
 			Defuses int64 `json:"defuses"`
 		} `json:"defuses"`
 	} `json:"top_stats"`
 	TopMatches struct {
 		BiggestLoss struct {
-			TeamAgainstStruct
+			TeamAgainst
 			Rounds int64 `json:"rounds"`
 		} `json:"biggest_loss"`
 		BiggestWin struct {
-			TeamAgainstStruct
+			TeamAgainst
 			Rounds int64 `json:"rounds"`
 		} `json:"biggest_win"`
 		MostRounds struct {
-			TeamAgainstStruct
+			TeamAgainst
 			Rounds int64 `json:"rounds"`
 		} `json:"most_rounds"`
 	} `json:"top_matches"`
 }
 
-// CsTeamCommonStatsStruct holds information common to multiple JSON objects.
-type CsTeamCommonStatsStruct struct {
+// CsTeamCommonStats holds information common to multiple JSON objects.
+type CsTeamCommonStats struct {
 	NrMatches      int64   `json:"nr_matches"`
 	CtRounds       int64   `json:"ct_rounds"`
 	CtWins         int64   `json:"ct_wins"`
@@ -185,37 +185,37 @@ type DotaTeamStats struct {
 	} `json:"faction_stats"`
 	Drafts struct {
 		Own struct {
-			MostPicked []DotaHeroWithWinsStruct `json:"most_picked"`
-			MostBanned []DotaHeroWithWinsStruct `json:"most_banned"`
+			MostPicked []DotaHeroWithWins `json:"most_picked"`
+			MostBanned []DotaHeroWithWins `json:"most_banned"`
 		} `json:"own"`
 		Opponents struct {
-			MostPicked []DotaHeroWithWinsStruct `json:"most_picked"`
-			MostBanned []DotaHeroWithWinsStruct `json:"most_banned"`
+			MostPicked []DotaHeroWithWins `json:"most_picked"`
+			MostBanned []DotaHeroWithWins `json:"most_banned"`
 		} `json:"opponents"`
 	} `json:"drafts"`
 	TopStats struct {
 		Kills struct {
-			DotaPlayerAgainstStruct
+			DotaPlayerAgainst
 			Kills int64 `json:"kills"`
 		} `json:"kills"`
 		Gpm struct {
-			DotaPlayerAgainstStruct
+			DotaPlayerAgainst
 			Gpm float64 `json:"gpm"`
 		} `json:"gpm"`
 		Xpm struct {
-			DotaPlayerAgainstStruct
+			DotaPlayerAgainst
 			Xpm float64 `json:"xpm"`
 		} `json:"xpm"`
 		DmgGiven struct {
-			DotaPlayerAgainstStruct
+			DotaPlayerAgainst
 			DmgGiven float64 `json:"dmg_given"`
 		} `json:"dmg_given"`
 		CreepKills struct {
-			DotaPlayerAgainstStruct
+			DotaPlayerAgainst
 			LastHits int64 `json:"last_hits"`
 		} `json:"creep_kills"`
 		CreepDenies struct {
-			DotaPlayerAgainstStruct
+			DotaPlayerAgainst
 			Denies int64 `json:"denies"`
 		} `json:"creep_denies"`
 	} `json:"top_stats"`
@@ -223,21 +223,21 @@ type DotaTeamStats struct {
 		AvgLength float64 `json:"avg_length"`
 		Longest   struct {
 			Won struct {
-				TeamAgainstStruct
+				TeamAgainst
 				Length int64 `json:"length"`
 			} `json:"won"`
 			Lost struct {
-				TeamAgainstStruct
+				TeamAgainst
 				Length int64 `json:"length"`
 			} `json:"lost"`
 		} `json:"longest"`
 		Shortest struct {
 			Won struct {
-				TeamAgainstStruct
+				TeamAgainst
 				Length int64 `json:"length"`
 			} `json:"won"`
 			Lost struct {
-				TeamAgainstStruct
+				TeamAgainst
 				Length int64 `json:"length"`
 			} `json:"lost"`
 		} `json:"shortest"`
@@ -245,11 +245,11 @@ type DotaTeamStats struct {
 		Kpm    struct {
 			Highest struct {
 				Kpm float64 `json:"kpm"`
-				TeamAgainstStruct
+				TeamAgainst
 			} `json:"highest"`
 			Lowest struct {
 				Kpm float64 `json:"kpm"`
-				TeamAgainstStruct
+				TeamAgainst
 			} `json:"lowest"`
 		} `json:"kpm"`
 	} `json:"top_matches"`
@@ -276,82 +276,82 @@ type LolTeamStats struct {
 		} `json:"champion"`
 	} `json:"champions"`
 	TopStats struct {
-		Kills               LolPlayerAgainstStruct  `json:"kills"`
-		Gpm                 LolPlayerAgainstStruct  `json:"gpm"`
-		Xpm                 LolPlayerAgainstStruct  `json:"xpm"`
-		DoubleKills         *LolPlayerAgainstStruct `json:"double_kills"`
-		TripleKills         *LolPlayerAgainstStruct `json:"triple_kills"`
-		QuadraKills         *LolPlayerAgainstStruct `json:"quadra_kills"`
-		PentaKills          *LolPlayerAgainstStruct `json:"Penta_kills"`
-		UnrealKills         *LolPlayerAgainstStruct `json:"Unreal_kills"`
-		LargestKillingSpree *LolPlayerAgainstStruct `json:"largest_killing_spree"`
-		LargestMultiKill    *LolPlayerAgainstStruct `json:"largest_multi_kill"`
+		Kills               LolPlayerAgainst  `json:"kills"`
+		Gpm                 LolPlayerAgainst  `json:"gpm"`
+		Xpm                 LolPlayerAgainst  `json:"xpm"`
+		DoubleKills         *LolPlayerAgainst `json:"double_kills"`
+		TripleKills         *LolPlayerAgainst `json:"triple_kills"`
+		QuadraKills         *LolPlayerAgainst `json:"quadra_kills"`
+		PentaKills          *LolPlayerAgainst `json:"Penta_kills"`
+		UnrealKills         *LolPlayerAgainst `json:"Unreal_kills"`
+		LargestKillingSpree *LolPlayerAgainst `json:"largest_killing_spree"`
+		LargestMultiKill    *LolPlayerAgainst `json:"largest_multi_kill"`
 	} `json:"top_stats"`
 	TopMatches struct {
 		Kpm struct {
 			Avg     float64 `json:"avg"` // Only lol
 			Highest struct {
-				LolTeamAgainstStruct
+				LolTeamAgainst
 			} `json:"highest"`
 			Lowest struct {
-				LolTeamAgainstStruct
+				LolTeamAgainst
 			} `json:"lowest"`
 		} `json:"kpm"`
 		Length struct {
 			Avg     float64 `json:"avg"`
 			Longest struct {
-				Won  LolTeamAgainstStruct `json:"won"`
-				Lost LolTeamAgainstStruct `json:"lost"`
+				Won  LolTeamAgainst `json:"won"`
+				Lost LolTeamAgainst `json:"lost"`
 			} `json:"longest"`
 			Shortest struct {
-				Won  LolTeamAgainstStruct `json:"won"`
-				Lost LolTeamAgainstStruct `json:"lost"`
+				Won  LolTeamAgainst `json:"won"`
+				Lost LolTeamAgainst `json:"lost"`
 			} `json:"shortest"`
 		} `json:"length"`
 	} `json:"top_matches"`
 }
 
-// TeamAgainstStruct is a collection of common data when examining specific stats.
+// TeamAgainst is a collection of common data when examining specific stats.
 // It is grouped with the specific stat in another struct.
-type TeamAgainstStruct struct {
-	MatchId int64       `json:"match_id"`
-	Against *TeamStruct `json:"against"` // Declared as pointer to avoid invalid recursive type
+type TeamAgainst struct {
+	MatchId int64 `json:"match_id"`
+	Against *Team `json:"against"` // Declared as pointer to avoid invalid recursive type
 }
 
-// DotaPlayerAgainstStruct is a grouping of PlayerAgainstStruct and a HeroStruct
-type DotaPlayerAgainstStruct struct {
-	PlayerAgainstStruct
-	Hero HeroStruct `json:"hero"`
+// DotaPlayerAgainst is a grouping of PlayerAgainst and a Hero
+type DotaPlayerAgainst struct {
+	PlayerAgainst
+	Hero Hero `json:"hero"`
 }
 
-type LolTeamAgainstStruct struct {
-	Value   float64      `json:"value"`
-	MatchId int64        `json:"match_id"`
-	Against RosterStruct `json:"against"`
+type LolTeamAgainst struct {
+	Value   float64 `json:"value"`
+	MatchId int64   `json:"match_id"`
+	Against Roster  `json:"against"`
 }
 
-type LolPlayerAgainstStruct struct {
+type LolPlayerAgainst struct {
 	Value    float64 `json:"value"`
 	PlayerId int64   `json:"player_id"`
 	MatchId  int64   `json:"match_id"`
 	Champion struct {
 		Name string `json:"name"`
 	} `json:"champion"`
-	Against RosterStruct `json:"against"`
+	Against Roster `json:"against"`
 }
 
-// PlayerAgainstStruct is a collection of common data when examining specific stats.
+// PlayerAgainst is a collection of common data when examining specific stats.
 // It is grouped with the specific stat in another struct.
-type PlayerAgainstStruct struct {
-	PlayerId int64       `json:"player_id"`
-	Against  *TeamStruct `json:"against"` // Declared as pointer to avoid invalid recursive type
-	MatchId  int64       `json:"match_id"`
+type PlayerAgainst struct {
+	PlayerId int64 `json:"player_id"`
+	Against  *Team `json:"against"` // Declared as pointer to avoid invalid recursive type
+	MatchId  int64 `json:"match_id"`
 }
 
-// DotaHeroWithAmountStruct holds information about a Dota Hero and an integer representing
+// DotaHeroWithAmount holds information about a Dota Hero and an integer representing
 // and amount (e.g amount of times picked).
-type DotaHeroWithWinsStruct struct {
-	Amount int64      `json:"amount"`
-	Wins   int64      `json:"wins"`
-	Hero   HeroStruct `json:"hero"`
+type DotaHeroWithWins struct {
+	Amount int64 `json:"amount"`
+	Wins   int64 `json:"wins"`
+	Hero   Hero  `json:"hero"`
 }

--- a/structs/tournament.go
+++ b/structs/tournament.go
@@ -1,49 +1,49 @@
 package structs
 
-// TournamentStructPaginated holds a list of TournamentStruct as well as information about pages
-type TournamentStructPaginated struct {
-	LastPage    int64              `json:"last_page,omitempty"`
-	CurrentPage int64              `json:"current_page,omitempty"`
-	Data        []TournamentStruct `json:"data,omitempty"`
+// PaginatedTournaments holds a list of Tournament as well as information about pages
+type PaginatedTournaments struct {
+	LastPage    int64        `json:"last_page,omitempty"`
+	CurrentPage int64        `json:"current_page,omitempty"`
+	Data        []Tournament `json:"data,omitempty"`
 }
 
-// TournamentStruct represents a tournament (i.e a structured group of Series').
-type TournamentStruct struct {
-	Id               int64                  `json:"id,omitempty"`
-	Title            string                 `json:"title,omitempty"`
-	ShortTitle       string                 `json:"short_title,omitempty"`
-	Country          CountryStruct          `json:"country,omitempty"`
-	City             string                 `json:"city,omitempty"`
-	Tier             int64                  `json:"tier"`
-	Description      string                 `json:"description,omitempty"`
-	ShortDescription string                 `json:"short_description,omitempty"`
-	Format           string                 `json:"format,omitempty"`
-	Start            *string                `json:"start"`      // Datettime
-	End              *string                `json:"end"`        // Datettime
-	DeletedAt        *string                `json:"deleted_at"` // Datettime
-	Url              string                 `json:"url,omitempty"`
-	HasPbpStats      bool                   `json:"has_pbpstats"`
-	Images           TournamentImagesStruct `json:"images,omitempty"`
-	PrizepoolString  PrizepoolStruct        `json:"prizepool_string,omitempty"`
-	Links            LinksStruct            `json:"links,omitempty"`
-	NextSeries       *SeriesStruct          `json:"next_series"`
-	Series           []SeriesStruct         `json:"series,omitempty"`  // Optional
-	Stages           []StageStruct          `json:"stages,omitempty"`  // Optional
-	Rosters          []RosterStruct         `json:"rosters,omitempty"` // Optional
-	Game             GameStruct             `json:"game,omitempty"`
-	Casters          []CasterStruct         `json:"casters"`
+// Tournament represents a tournament (i.e a structured group of Series').
+type Tournament struct {
+	Id               int64            `json:"id,omitempty"`
+	Title            string           `json:"title,omitempty"`
+	ShortTitle       string           `json:"short_title,omitempty"`
+	Country          Country          `json:"country,omitempty"`
+	City             string           `json:"city,omitempty"`
+	Tier             int64            `json:"tier"`
+	Description      string           `json:"description,omitempty"`
+	ShortDescription string           `json:"short_description,omitempty"`
+	Format           string           `json:"format,omitempty"`
+	Start            *string          `json:"start"`      // Datettime
+	End              *string          `json:"end"`        // Datettime
+	DeletedAt        *string          `json:"deleted_at"` // Datettime
+	Url              string           `json:"url,omitempty"`
+	HasPbpStats      bool             `json:"has_pbpstats"`
+	Images           TournamentImages `json:"images,omitempty"`
+	PrizepoolString  Prizepool        `json:"prizepool_string,omitempty"`
+	Links            Links            `json:"links,omitempty"`
+	NextSeries       *Series          `json:"next_series"`
+	Series           []Series         `json:"series,omitempty"`  // Optional
+	Stages           []Stage          `json:"stages,omitempty"`  // Optional
+	Rosters          []Roster         `json:"rosters,omitempty"` // Optional
+	Game             Game             `json:"game,omitempty"`
+	Casters          []Caster         `json:"casters"`
 }
 
-// PrizepoolStruct holds information about a Tournament's prizepool.
-type PrizepoolStruct struct {
+// Prizepool holds information about a Tournament's prizepool.
+type Prizepool struct {
 	Total  string `json:"total,omitempty"`
 	First  string `json:"first,omitempty"`
 	Second string `json:"second,omitempty"`
 	Third  string `json:"third,omitempty"`
 }
 
-// LinksStruct holds information about links relevant to a Tournament.
-type LinksStruct struct {
+// Links holds information about links relevant to a Tournament.
+type Links struct {
 	Website string `json:"website"`
 	Youtube string `json:"youtube"`
 }

--- a/structs/weapon.go
+++ b/structs/weapon.go
@@ -1,7 +1,7 @@
 package structs
 
-// WeaponStruct holds information about a CS:GO weapon.
-type WeaponStruct struct {
+// Weapon holds information about a CS:GO weapon.
+type Weapon struct {
 	Images struct {
 		Small string `json:"small"`
 	} `json:"images"`


### PR DESCRIPTION
* Errors are properly propagated
    - `ErrorStruct` now implements the `error` interface and no error is left behind (everything is propagated up to the caller). 
    - This is a breaking change as everything now return `error` instead of `ErrorStruct`
* Series chain
    - The `Chain` fields of `SeriesStruct` had wrong structure which leads to (silent) errors
* Go module
    - This will be released as a go module with at v3.0.0 which is the [recommended way to go about it](https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher).