### PR TITLE
Increase timeout of outgoing requests

### DIFF
--- a/http_wrapper.go
+++ b/http_wrapper.go
@@ -34,7 +34,7 @@ func performRequest(targetUrl string, params Parameters) (int, []byte, error) {
 
 // apiCall performs the actual http request and returns the resulting statuscode and body.
 func apiCall(req *http.Request) (int, []byte, error) {
-	client := &http.Client{Timeout: 20 * time.Second}
+	client := &http.Client{Timeout: 55 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
 		return 0, nil, err


### PR DESCRIPTION
The current 20 second timeout was arbitrarily chosen and can be hit in
some cases. This increase the timeout to something more aligned with the
server-side timeout.

Fix #14